### PR TITLE
Fix time tag index comparision.

### DIFF
--- a/osu.Framework.Font.Tests/Graphics/TimeTagIndexTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/TimeTagIndexTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using System;
+
+namespace osu.Karaoke.Font.Tests.Graphics
+{
+    [TestFixture]
+    public class TimeTagIndexTest
+    {
+        [TestCase(1, 1)]
+        [TestCase(1.5, 1.5)]
+        [TestCase(-1.5, -1.5)]
+        public void TestOperatorEqual(double tone1, double tone2)
+        {
+            Assert.AreEqual(numberToTimeTagIndex(tone1), numberToTimeTagIndex(tone2));
+        }
+
+        [TestCase(-1, 1)]
+        [TestCase(1, -1)]
+        [TestCase(1.5, -1.5)]
+        [TestCase(1.5, 1)]
+        [TestCase(-1.5, -1)]
+        [TestCase(-1.5, -2)]
+        public void TestOperatorNotEqual(double tone1, double tone2)
+        {
+            Assert.AreNotEqual(numberToTimeTagIndex(tone1), numberToTimeTagIndex(tone2));
+        }
+
+        [TestCase(1, 0, true)]
+        [TestCase(1, 0.5, true)]
+        [TestCase(1, 1, false)]
+        [TestCase(1, 1.5, false)]
+        public void TestOperatorGreater(double tone1, double tone2, bool match)
+        {
+            Assert.AreEqual(numberToTimeTagIndex(tone1) > numberToTimeTagIndex(tone2), match);
+        }
+
+        [TestCase(1, 0, true)]
+        [TestCase(1, 0.5, true)]
+        [TestCase(1, 1, true)]
+        [TestCase(1, 1.5, false)]
+        public void TestOperatorGreaterOrEqual(double tone1, double tone2, bool match)
+        {
+            Assert.AreEqual(numberToTimeTagIndex(tone1) >= numberToTimeTagIndex(tone2), match);
+        }
+
+        [TestCase(-1, 0, true)]
+        [TestCase(-1, -0.5, true)]
+        [TestCase(-1, -1, false)]
+        [TestCase(-1, -1.5, false)]
+        public void TestOperatorLess(double tone1, double tone2, bool match)
+        {
+            Assert.AreEqual(numberToTimeTagIndex(tone1) < numberToTimeTagIndex(tone2), match);
+        }
+
+        [TestCase(-1, 0, true)]
+        [TestCase(-1, -0.5, true)]
+        [TestCase(-1, -1, true)]
+        [TestCase(-1, -1.5, false)]
+        public void TestOperatorLessOrEqual(double tone1, double tone2, bool match)
+        {
+            Assert.AreEqual(numberToTimeTagIndex(tone1) <= numberToTimeTagIndex(tone2), match);
+        }
+
+        private TimeTagIndex numberToTimeTagIndex(double tone)
+        {
+            var half = Math.Abs(tone) % 1 == 0.5;
+            var scale = tone < 0 ? (int)tone - (half ? 1 : 0) : (int)tone;
+            return new TimeTagIndex(scale, half ? TimeTagIndex.IndexState.End : TimeTagIndex.IndexState.Start);
+        }
+
+    }
+}

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -9,11 +9,11 @@
     <RootNamespace>osu.Karaoke.Font.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1016.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1030.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework.Font\osu.Framework.Font.csproj" />

--- a/osu.Framework.Font/Graphics/Sprites/TimeTagIndex.cs
+++ b/osu.Framework.Font/Graphics/Sprites/TimeTagIndex.cs
@@ -29,9 +29,9 @@ namespace osu.Framework.Graphics.Sprites
                 return 0;
 
             if (State == IndexState.Start)
-                return 1;
+                return -1;
 
-            return -1;
+            return 1;
         }
 
         public bool Equals(TimeTagIndex other)
@@ -72,9 +72,9 @@ namespace osu.Framework.Graphics.Sprites
 
         public enum IndexState
         {
-            Start = 1,
+            Start = 0,
 
-            End = 0
+            End = 1
         }
     }
 }

--- a/osu.Framework.Font/osu.Framework.Font.csproj
+++ b/osu.Framework.Font/osu.Framework.Font.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
   <PropertyGroup Label="Nuget">
     <GenerateProgramFile>false</GenerateProgramFile>
-    <AssemblyName>osu.Framework.Font</AssemblyName>
+    <AssemblyName>osu.Framework.KaraokeFont</AssemblyName>
     <RootNamespace>osu.Framework</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Description>Unofficial support extra font effect for osu!framework.</Description>
     <Copyright>https://github.com/karaoke-dev/osu-framework-fontk</Copyright>
     <PackageProjectUrl>https://github.com/karaoke-dev/osu-framework-font</PackageProjectUrl>
@@ -23,11 +23,11 @@
     <Company>karaoke!</Company>
     <Product>karaoke!</Product>
     <PackageReleaseNotes>喵</PackageReleaseNotes>
-    <PackageId>osu.Karaoke.font</PackageId>
+    <PackageId>osu.Framework.KaraokeFont</PackageId>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework" Version="2020.1019.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.1105.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. update nuget version.
2. timetag's end should larger the start in comparision.
3. add test case for that.
4. change package name to named `osu.Framework.KaraokeFont`