### PR TITLE
Fix performance issue

### DIFF
--- a/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
+++ b/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
@@ -25,7 +25,9 @@ namespace osu.Framework.Font.Tests.Visual
         [Resolved]
         private ShaderManager shaderManager { get; set; }
 
-        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+        private readonly Container content;
+
+        protected override Container<Drawable> Content => content;
 
         protected BackgroundGridTestSample()
         {
@@ -58,7 +60,18 @@ namespace osu.Framework.Font.Tests.Visual
                         Origin = Anchor.Centre,
                         Colour = Color4.Purple,
                     },
-                    Content,
+                    content = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new DraggableCircle
+                    {
+                        Name = "Test background change object",
+                        Size = new Vector2(GRID_SIZE),
+                        Anchor = Anchor.BottomRight,
+                        Origin = Anchor.BottomRight,
+                        Colour = Color4.Green,
+                    },
                 }
             });
         }

--- a/osu.Framework.Font.Tests/Visual/Shaders/ShaderTestScene.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/ShaderTestScene.cs
@@ -73,6 +73,9 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
 
             private readonly List<IShader> shaders = new();
 
+            // todo: should have a better way to let user able to customize formats?
+            private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new();
+
             public IReadOnlyList<IShader> Shaders
             {
                 get => shaders;
@@ -95,9 +98,8 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                 RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
             }
 
-            // todo: should have a better way to let user able to customize formats?
             protected override DrawNode CreateDrawNode()
-                => new TestShaderContainerShaderEffectDrawNode(this, new MultiShaderBufferedDrawNodeSharedData());
+                => new TestShaderContainerShaderEffectDrawNode(this, sharedData);
 
             /// <summary>
             /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using osu.Framework.Graphics.Colour;
@@ -92,6 +91,10 @@ namespace osu.Framework.Graphics
             {
                 foreach (var frameBuffer in drawFrameBuffers)
                 {
+                    // got no idea why happened.
+                    if (frameBuffer.Texture == null)
+                        break;
+
                     DrawFrameBuffer(frameBuffer, DrawRectangle, Color4.White);
                 }
             }
@@ -111,8 +114,8 @@ namespace osu.Framework.Graphics
 
             foreach (var shader in shaders)
             {
-                var current = getSourceFrameBuffer(shader);
-                var target = SharedData.ShaderBuffers[shader];
+                var current = SharedData.GetSourceFrameBuffer(shader);
+                var target = SharedData.GetTargetFrameBuffer(shader);
 
                 if (shader is IStepShader stepShader)
                 {
@@ -148,22 +151,6 @@ namespace osu.Framework.Graphics
                     DrawFrameBuffer(current, new RectangleF(0, 0, current.Texture.Width, current.Texture.Height), ColourInfo.SingleColour(Color4.White));
                     shader.Unbind();
                 }
-            }
-
-            FrameBuffer getSourceFrameBuffer(IShader targetShader)
-            {
-                if (!(targetShader is IStepShader stepShader))
-                    return SharedData.CurrentEffectBuffer;
-
-                var fromShader = stepShader.FromShader;
-                if (fromShader == null)
-                    return SharedData.CurrentEffectBuffer;
-
-                var shaderBuffers = SharedData.ShaderBuffers;
-                if (!shaderBuffers.ContainsKey(fromShader))
-                    throw new DirectoryNotFoundException("Frame buffer does not found in target shader.");
-
-                return shaderBuffers[fromShader];
             }
         }
     }

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Graphics
 
         protected new MultiShaderBufferedDrawNodeSharedData SharedData => (MultiShaderBufferedDrawNodeSharedData)base.SharedData;
 
-        private IShader[] shaders = { };
-
         private readonly double loadTime;
 
         public MultiShaderBufferedDrawNode(IBufferedDrawable source, DrawNode child, MultiShaderBufferedDrawNodeSharedData sharedData)
@@ -33,19 +31,13 @@ namespace osu.Framework.Graphics
         public override void ApplyState()
         {
             base.ApplyState();
-
-            if (shaders.SequenceEqual(Source.Shaders))
-                return;
-
-            // should clear buffer if property changed because might be shader amount changed.
-            shaders = Source.Shaders.ToArray();
-            SharedData.CreateDefaultFrameBuffers(shaders);
+            SharedData.UpdateFrameBuffers(Source.Shaders.ToArray());
         }
 
         protected override long GetDrawVersion()
         {
             // if contains shader that need to apply time, then need to force run populate contents in each frame.
-            if (ContainTimePropertyShader(shaders))
+            if (ContainTimePropertyShader(SharedData.Shaders))
             {
                 ResetDrawVersion();
             }
@@ -91,10 +83,6 @@ namespace osu.Framework.Graphics
             {
                 foreach (var frameBuffer in drawFrameBuffers)
                 {
-                    // got no idea why happened.
-                    if (frameBuffer.Texture == null)
-                        break;
-
                     DrawFrameBuffer(frameBuffer, DrawRectangle, Color4.White);
                 }
             }
@@ -107,6 +95,7 @@ namespace osu.Framework.Graphics
 
         private void drawFrameBuffer()
         {
+            var shaders = SharedData.Shaders;
             if (!shaders.Any())
                 return;
 

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics
 
         public void CreateDefaultFrameBuffers(IShader[] shaders)
         {
-            shaderBuffers.Clear();
+            clearBuffers();
 
             var filterMode = PixelSnapping ? All.Nearest : All.Linear;
 
@@ -57,7 +57,11 @@ namespace osu.Framework.Graphics
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+            clearBuffers();
+        }
 
+        private void clearBuffers()
+        {
             // clear all frame in the dictionary.
             foreach (var shaderBuffer in shaderBuffers)
             {

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -26,6 +26,9 @@ namespace osu.Framework.Graphics.Sprites
         private readonly MaskingContainer<T> backLyricTextContainer;
         private readonly T backLyricText;
 
+        // todo: should have a better way to let user able to customize formats?
+        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
+
         public IShader TextureShader { get; private set; }
         public IShader RoundedTextureShader { get; private set; }
 

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
@@ -18,9 +18,8 @@ namespace osu.Framework.Graphics.Sprites
             return ToScreenSpace(newRectangle);
         }
 
-        // todo: should have a better way to let user able to customize formats?
         protected override DrawNode CreateDrawNode()
-            => new KaraokeSpriteTextShaderEffectDrawNode(this, new MultiShaderBufferedDrawNodeSharedData());
+            => new KaraokeSpriteTextShaderEffectDrawNode(this, sharedData);
 
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -27,6 +27,9 @@ namespace osu.Framework.Graphics.Sprites
         private const float default_text_size = 48;
         private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ' };
 
+        // todo: should have a better way to let user able to customize formats?
+        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
+
         [Resolved]
         private FontStore store { get; set; }
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -21,9 +21,8 @@ namespace osu.Framework.Graphics.Sprites
             return ToScreenSpace(newRectangle);
         }
 
-        // todo: should have a better way to let user able to customize formats?
         protected override DrawNode CreateDrawNode()
-            => new LyricSpriteTextShaderEffectDrawNode(this, new MultiShaderBufferedDrawNodeSharedData());
+            => new LyricSpriteTextShaderEffectDrawNode(this, sharedData);
 
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/136724759-5d95c9d1-e296-4fcd-93ac-b33fbc8b4850.png)
Fix issue found in #64 

And what's fixed in this PR:
- shared data should only create one instance brcause `CreateDrawNode()` will call 3 times if create a drawable(got no reason why 🤔 )
- rewrite frame buffer GC logic, should call `GLWrapper.ScheduleDisposal(() => Dispose(true))` and only dispose unneed frame buffer.
- make shader buffers private in `MultiShaderBufferedDrawNodeSharedData` (code quality issue).
