### PR TITLE
Add missing toSRGB() to some shaders.

### DIFF
--- a/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
+++ b/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shaders;
@@ -22,6 +23,10 @@ namespace osu.Framework.Font.Tests.Visual
         private const int column = 12;
         private const int row = 6;
         private const int spacing = 5;
+
+        protected const string RED = "#FF0000";
+        protected const string GREEN = "#00FF00";
+        protected const string BLUE = "#0000FF";
 
         [Resolved]
         private ShaderManager shaderManager { get; set; }
@@ -71,7 +76,7 @@ namespace osu.Framework.Font.Tests.Visual
                         Size = new Vector2(GRID_SIZE),
                         Anchor = Anchor.BottomRight,
                         Origin = Anchor.BottomRight,
-                        Colour = Color4.Green,
+                        Colour = Color4Extensions.FromHex(GREEN)
                     },
                 }
             });

--- a/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
+++ b/osu.Framework.Font.Tests/Visual/BackgroundGridTestSample.cs
@@ -24,9 +24,9 @@ namespace osu.Framework.Font.Tests.Visual
         private const int row = 6;
         private const int spacing = 5;
 
-        protected const string RED = "#FF0000";
-        protected const string GREEN = "#00FF00";
-        protected const string BLUE = "#0000FF";
+        protected const string RED = "#AF0000";
+        protected const string GREEN = "#00AF00";
+        protected const string BLUE = "#0000AF";
 
         [Resolved]
         private ShaderManager shaderManager { get; set; }

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneOutlineShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneOutlineShader.cs
@@ -11,7 +11,9 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
 {
     public class TestSceneOutlineShader : TestSceneInternalShader
     {
-        [TestCase("#FF0000FF")] // will make the inner texture red
+        [TestCase(RED)] // will make the inner texture red
+        [TestCase(GREEN)] // will make the inner texture green
+        [TestCase(BLUE)] // will make the inner texture blur
         [TestCase("#FFFFFFFF")] // will make the inner texture white
         [TestCase("#000000FF")] // will make the inner texture black
         [TestCase("#00000000")] // will not affect inner texture
@@ -31,10 +33,10 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
             });
         }
 
-        [TestCase(0, "#FF0000")]
-        [TestCase(10, "#00FF00")]
-        [TestCase(20, "#0000FF")]
-        [TestCase(100, "#0000FF")] // it might cause performance issue if set radius too large.
+        [TestCase(0, RED)]
+        [TestCase(10, GREEN)]
+        [TestCase(20, BLUE)]
+        [TestCase(100, BLUE)] // it might cause performance issue if set radius too large.
         public void TestOutline(int radius, string colour)
         {
             AddStep("Apply shader", () =>

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShader.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shaders;
@@ -33,14 +34,14 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(50),
-                        Colour = Color4.Red,
+                        Colour = Color4Extensions.FromHex(RED),
                     },
                     new DraggableCircle
                     {
                         Size = new Vector2(50),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Colour = Color4.Blue,
+                        Colour = Color4Extensions.FromHex(BLUE),
                     },
                     new DraggableTriangle
                     {
@@ -48,7 +49,7 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                         Size = new Vector2(50),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Colour = Color4.Green,
+                        Colour = Color4Extensions.FromHex(GREEN)
                     },
                     new DraggableText
                     {
@@ -72,7 +73,7 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                     Name = name,
                     Anchor = position,
                     Origin = position,
-                    Colour = Color4.Red,
+                    Colour = Color4Extensions.FromHex(RED),
                     Size = new Vector2(GRID_SIZE),
                 };
         }

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShadowShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShadowShader.cs
@@ -11,8 +11,9 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
 {
     public class TestSceneShadowShader : TestSceneInternalShader
     {
-        [TestCase("#FFFF00", "(10,10)")]
-        [TestCase("#FF0000", "(-20,-20)")]
+        [TestCase(RED, "(10,10)")]
+        [TestCase(GREEN, "(-20,-20)")]
+        [TestCase(BLUE, "(0,0)")]
         public void TestProperty(string colour, string offset)
         {
             AddStep("Apply shader", () =>

--- a/osu.Framework.Font/Resources/Shaders/sh_Outline.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Outline.fs
@@ -170,7 +170,7 @@ void main(void)
 	angelPosition[126] = lowp vec2(-0.05, 1.00);
 	angelPosition[127] = lowp vec2(0.00, 1.00);
 
-	lowp vec4 sample = texture2D(m_Sampler, v_TexCoord);
+	lowp vec4 sample = toSRGB(texture2D(m_Sampler, v_TexCoord));
 	lowp vec4 originColur = vec4(mix(sample.rgb, g_Colour.rgb, g_Colour.a), sample.a);
 	lowp vec4 outlineColour = outline(m_Sampler, g_Radius, v_TexCoord, g_TexSize, g_OutlineColour);
 

--- a/osu.Framework.Font/Resources/Shaders/sh_Pixel.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Pixel.fs
@@ -1,4 +1,5 @@
 // see the demo: https://www.geeks3d.com/20101029/shader-library-pixelation-post-processing-effect-glsl/
+#include "sh_Utils.h"
 
 varying mediump vec2 v_TexCoord;
 
@@ -14,5 +15,5 @@ void main(void)
 	uv = uv * separaorParts;
     uv = floor(uv);
     uv = uv / separaorParts;
-    gl_FragColor = texture2D(m_Sampler, uv);
+    gl_FragColor = toSRGB(texture2D(m_Sampler, uv));
 }

--- a/osu.Framework.Font/Resources/Shaders/sh_Rainbow.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Rainbow.fs
@@ -17,7 +17,7 @@ uniform float g_Mix;
 void main(void)
 {
     float pos = (v_TexCoord.y - g_Uv[0]) / (g_Uv[1] - g_Uv[0]);
-    vec4 texColor = texture2D(m_Sampler, v_TexCoord);
+    vec4 texColor = toSRGB(texture2D(m_Sampler, v_TexCoord));
     
     vec4 col = vec4(g_Section * ((g_Time * g_Speed) + pos), g_Saturation, g_Brightness, 1);
     vec4 finalCol = mix(texColor, vec4(hsv2rgb(col).xyz, texColor.a), g_Mix);

--- a/osu.Framework.Font/Resources/Shaders/sh_RepeatMovingBackground.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_RepeatMovingBackground.fs
@@ -1,4 +1,5 @@
 ﻿// see : https://github.com/kiwipxl/GLSL-shaders/blob/master/repeat.glsl
+#include "sh_Utils.h"
 
 varying vec2 v_TexCoord;
 varying vec4 v_Colour;
@@ -35,5 +36,5 @@ void main(void) {
     // get point colour from sample.
     vec4 texColor = texture2D(m_Sampler, v_TexCoord);
     vec4 repeatSampleColor = v_Colour * vec4(texture2D(g_RepeatSample, fixedTexCoord).xyz, texColor.a);
-    gl_FragColor = mix(texColor, repeatSampleColor, g_Mix);
+    gl_FragColor = toSRGB(mix(texColor, repeatSampleColor, g_Mix));
 }

--- a/osu.Framework.Font/Resources/Shaders/sh_Shadow.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Shadow.fs
@@ -1,3 +1,5 @@
+#include "sh_Utils.h"
+
 varying mediump vec2 v_TexCoord;
 
 uniform lowp sampler2D m_Sampler;
@@ -13,7 +15,7 @@ lowp vec4 shadow(sampler2D tex, mediump vec2 texCoord, mediump vec2 texSize, med
 
 void main(void)
 {
-	lowp vec4 texture = texture2D(m_Sampler, v_TexCoord);
+	lowp vec4 texture = toSRGB(texture2D(m_Sampler, v_TexCoord));
 	lowp vec4 shadow = shadow(m_Sampler, v_TexCoord, g_TexSize, g_Colour, g_Offset);
 	gl_FragColor = mix(shadow, texture, texture.a);
 }


### PR DESCRIPTION
Closes issue #142.

What's done in this PR:
- add color hex code const property for better adjust the color for testing purpose.
- make red, green and blue not that pure(for testing purpose).
- fix the SRGB issue in every shader.