### PR TITLE
Fix CRT shader cannot run on the osx.

### DIFF
--- a/osu.Framework.Font.Tests/Resources/Shaders/sh_CRT.fs
+++ b/osu.Framework.Font.Tests/Resources/Shaders/sh_CRT.fs
@@ -3,7 +3,7 @@
 varying mediump vec2 v_TexCoord;
 varying vec4 v_TexRect;
 
-const float gradient = 0.003f;
+const float gradient = 0.003;
 
 #define PI 3.1415926538
 


### PR DESCRIPTION
fixing having `'f' : syntax error: syntax error` issue.
Caused by the supported shader language version.