### PR TITLE
Fix left-side shader showing before first time-tag time.

### DIFF
--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+
+namespace osu.Framework.Font.Tests.Shaders
+{
+    public class OutlineShaderTest
+    {
+        [TestCase(10, -5, -5, 30, 30)]
+        [TestCase(0, 5, 5, 10, 10)]
+        [TestCase(-10, 5, 5, 10, 10)]
+        public void TestComputeCharacterDrawRectangle(int radius, float expectedX, float expectedY, float expectedWidth, float expectedHeight)
+        {
+            var shader = new OutlineShader
+            {
+                Radius = radius
+            };
+
+            var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
+            Assert.AreEqual(expectedX, rectangle.X);
+            Assert.AreEqual(expectedY, rectangle.Y);
+            Assert.AreEqual(expectedWidth, rectangle.Width);
+            Assert.AreEqual(expectedHeight, rectangle.Height);
+        }
+
+        [TestCase(10, -5, -5, 30, 30)]
+        [TestCase(0, 5, 5, 10, 10)]
+        [TestCase(-10, 5, 5, 10, 10)]
+        public void TestComputeScreenSpaceDrawQuad(int radius, float expectedX, float expectedY, float expectedWidth, float expectedHeight)
+        {
+            var shader = new OutlineShader
+            {
+                Radius = radius
+            };
+
+            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
+            var rectangle = quad.AABBFloat;
+            Assert.AreEqual(expectedX, rectangle.X);
+            Assert.AreEqual(expectedY, rectangle.Y);
+            Assert.AreEqual(expectedWidth, rectangle.Width);
+            Assert.AreEqual(expectedHeight, rectangle.Height);
+        }
+    }
+}

--- a/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+using osuTK;
+
+namespace osu.Framework.Font.Tests.Shaders
+{
+    public class ShadowShaderTest
+    {
+        private const float offset_x = 11;
+        private const float offset_y = 12;
+
+        [TestCase(offset_x, 0, 5, 5, 10 + offset_x, 10)] // Offset right
+        [TestCase(-offset_x, 0, 5 - offset_x, 5, 10 + offset_x, 10)] // Offset left
+        [TestCase(0, offset_y, 5, 5, 10, 10 + offset_y)] // Offset down
+        [TestCase(0, -offset_y, 5, 5 - offset_y, 10, 10 + offset_y)] // Offset up
+        public void TestComputeScreenSpaceDrawQuad(float offsetX, float offsetY, float expectedX, float expectedY, float expectedWidth, float expectedHeight)
+        {
+            var shader = new ShadowShader
+            {
+                ShadowOffset = new Vector2(offsetX, offsetY)
+            };
+
+            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
+            var rectangle = quad.AABBFloat;
+            Assert.AreEqual(expectedX, rectangle.X);
+            Assert.AreEqual(expectedY, rectangle.Y);
+            Assert.AreEqual(expectedWidth, rectangle.Width);
+            Assert.AreEqual(expectedHeight, rectangle.Height);
+        }
+    }
+}

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -1,0 +1,136 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+using osuTK;
+
+namespace osu.Framework.Font.Tests.Shaders
+{
+    public class StepShaderTest
+    {
+        [Test]
+        public void TestComputeCharacterDrawRectangle()
+        {
+            const int outline_radius = 10;
+            const int shadow_offset_x = 11;
+            const int shadow_offset_y = 12;
+
+            var shader = new StepShader
+            {
+                StepShaders = new ICustomizedShader[]
+                {
+                    new OutlineShader
+                    {
+                        Radius = outline_radius
+                    },
+                    new ShadowShader
+                    {
+                        ShadowOffset = new Vector2(shadow_offset_x, shadow_offset_y)
+                    }
+                }
+            };
+
+            var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
+            Assert.AreEqual(5 - outline_radius, rectangle.X);
+            Assert.AreEqual(5 - outline_radius, rectangle.Y);
+            Assert.AreEqual(10 + outline_radius * 2, rectangle.Width);
+            Assert.AreEqual(10 + outline_radius * 2, rectangle.Height);
+        }
+
+        [Test]
+        public void TestComputeScreenSpaceDrawQuad()
+        {
+            const int outline_radius = 10;
+            const int shadow_offset_x = 11;
+            const int shadow_offset_y = 12;
+
+            var shader = new StepShader
+            {
+                StepShaders = new ICustomizedShader[]
+                {
+                    new OutlineShader
+                    {
+                        Radius = outline_radius
+                    },
+                    new ShadowShader
+                    {
+                        ShadowOffset = new Vector2(shadow_offset_x, shadow_offset_y)
+                    }
+                }
+            };
+
+            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
+            var rectangle = quad.AABBFloat;
+            Assert.AreEqual(5 - outline_radius, rectangle.X);
+            Assert.AreEqual(5 - outline_radius, rectangle.Y);
+            Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_x, rectangle.Width);
+            Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_y, rectangle.Height);
+        }
+
+        [Test]
+        public void TestComputeCharacterDrawRectangleWithEmptyShader()
+        {
+            var shader = new StepShader();
+
+            var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
+            Assert.AreEqual(5, rectangle.X);
+            Assert.AreEqual(5, rectangle.Y);
+            Assert.AreEqual(10, rectangle.Width);
+            Assert.AreEqual(10, rectangle.Height);
+        }
+
+        [Test]
+        public void TestEmptyComputeScreenSpaceDrawQuadWithEmptyShader()
+        {
+            var shader = new StepShader();
+
+            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
+            var rectangle = quad.AABBFloat;
+            Assert.AreEqual(5, rectangle.X);
+            Assert.AreEqual(5, rectangle.Y);
+            Assert.AreEqual(10, rectangle.Width);
+            Assert.AreEqual(10, rectangle.Height);
+        }
+
+        [Test]
+        public void TestCharacterDrawRectangleWithNoneMatchedShader()
+        {
+            var shader = new StepShader
+            {
+                StepShaders = new[]
+                {
+                    new PixelShader()
+                }
+            };
+
+            var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
+            Assert.AreEqual(5, rectangle.X);
+            Assert.AreEqual(5, rectangle.Y);
+            Assert.AreEqual(10, rectangle.Width);
+            Assert.AreEqual(10, rectangle.Height);
+        }
+
+        [Test]
+        public void TestEmptyComputeScreenSpaceDrawQuadNoneMatchedShader()
+        {
+            var shader = new StepShader
+            {
+                StepShaders = new[]
+                {
+                    new PixelShader()
+                }
+            };
+
+            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
+            var rectangle = quad.AABBFloat;
+            Assert.AreEqual(5, rectangle.X);
+            Assert.AreEqual(5, rectangle.Y);
+            Assert.AreEqual(10, rectangle.Width);
+            Assert.AreEqual(10, rectangle.Height);
+        }
+    }
+}
+
+

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
 
             AddLabel("Timing");
 
-            AddSliderStep("Adjust clock time", 0, end_time + exrea_time, start_time - exrea_time, time =>
+            AddSliderStep("Adjust clock time", start_time - exrea_time, end_time + exrea_time, start_time, time =>
             {
                 manualClock.CurrentTime = time;
             });

--- a/osu.Framework.Font/Graphics/Shaders/IApplicableToCharacterSize.cs
+++ b/osu.Framework.Font/Graphics/Shaders/IApplicableToCharacterSize.cs
@@ -1,0 +1,12 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Primitives;
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public interface IApplicableToCharacterSize
+    {
+        RectangleF ComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle);
+    }
+}

--- a/osu.Framework.Font/Graphics/Shaders/IApplicableToDrawQuad.cs
+++ b/osu.Framework.Font/Graphics/Shaders/IApplicableToDrawQuad.cs
@@ -1,0 +1,12 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Primitives;
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public interface IApplicableToDrawQuad
+    {
+        Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad);
+    }
+}

--- a/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
@@ -2,12 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.Primitives;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class OutlineShader : InternalShader
+    public class OutlineShader : InternalShader, IApplicableToCharacterSize, IApplicableToDrawQuad
     {
         public override string ShaderName => "Outline";
 
@@ -30,6 +31,15 @@ namespace osu.Framework.Graphics.Shaders
 
             var size = current.Size;
             GetUniform<Vector2>(@"g_TexSize").UpdateValue(ref size);
+        }
+
+        public RectangleF ComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle)
+            => originalCharacterDrawRectangle.Inflate(Radius);
+
+        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad)
+        {
+            var rectangle = ComputeCharacterDrawRectangle(originDrawQuad.AABBFloat);
+            return Quad.FromRectangle(rectangle);
         }
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
@@ -34,7 +35,7 @@ namespace osu.Framework.Graphics.Shaders
         }
 
         public RectangleF ComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle)
-            => originalCharacterDrawRectangle.Inflate(Radius);
+            => originalCharacterDrawRectangle.Inflate(Math.Max(Radius, 0));
 
         public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad)
         {

--- a/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.Primitives;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class ShadowShader : InternalShader
+    public class ShadowShader : InternalShader, IApplicableToDrawQuad
     {
         public override string ShaderName => "Shadow";
 
@@ -25,6 +27,19 @@ namespace osu.Framework.Graphics.Shaders
 
             var size = current.Size;
             GetUniform<Vector2>(@"g_TexSize").UpdateValue(ref size);
+        }
+
+        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad)
+        {
+            var rectangle = originDrawQuad.AABBFloat.Inflate(new MarginPadding
+            {
+                Left = Math.Max(-ShadowOffset.X, 0),
+                Right = Math.Max(ShadowOffset.X, 0),
+                Top = Math.Max(ShadowOffset.Y, 0),
+                Bottom = Math.Max(-ShadowOffset.Y, 0),
+            });
+
+            return Quad.FromRectangle(rectangle);
         }
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
@@ -35,8 +35,8 @@ namespace osu.Framework.Graphics.Shaders
             {
                 Left = Math.Max(-ShadowOffset.X, 0),
                 Right = Math.Max(ShadowOffset.X, 0),
-                Top = Math.Max(ShadowOffset.Y, 0),
-                Bottom = Math.Max(-ShadowOffset.Y, 0),
+                Top = Math.Max(-ShadowOffset.Y, 0),
+                Bottom = Math.Max(ShadowOffset.Y, 0),
             });
 
             return Quad.FromRectangle(rectangle);

--- a/osu.Framework.Font/Graphics/Shaders/StepShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/StepShader.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class StepShader : IStepShader
+    public class StepShader : IStepShader, IApplicableToCharacterSize, IApplicableToDrawQuad
     {
         public string Name { get; set; }
 
@@ -45,5 +46,13 @@ namespace osu.Framework.Graphics.Shaders
 
         public void ApplyValue(FrameBuffer current)
             => throw new NotSupportedException();
+
+        public RectangleF ComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle) =>
+            StepShaders.OfType<IApplicableToCharacterSize>()
+                       .Aggregate(originalCharacterDrawRectangle, (rectangle, shader) => shader.ComputeCharacterDrawRectangle(rectangle));
+
+        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad) =>
+            StepShaders.OfType<IApplicableToDrawQuad>()
+                       .Aggregate(originDrawQuad, (rectangle, shader) => shader.ComputeScreenSpaceDrawQuad(rectangle));
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/StepShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/StepShader.cs
@@ -53,6 +53,6 @@ namespace osu.Framework.Graphics.Shaders
 
         public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad) =>
             StepShaders.OfType<IApplicableToDrawQuad>()
-                       .Aggregate(originDrawQuad, (rectangle, shader) => shader.ComputeScreenSpaceDrawQuad(rectangle));
+                       .Aggregate(originDrawQuad, (quad, shader) => shader.ComputeScreenSpaceDrawQuad(quad));
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -113,7 +113,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (value != null)
                     shaders.AddRange(value);
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate();
             }
         }
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Framework.Graphics.Extensions;
+using System.Linq;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
@@ -17,8 +17,12 @@ namespace osu.Framework.Graphics.Sprites
         protected override Quad ComputeScreenSpaceDrawQuad()
         {
             // make draw size become bigger (for not masking the shader).
-            var newRectangle = DrawRectangle.Scale(2);
-            return ToScreenSpace(newRectangle);
+            var quad = ToScreenSpace(DrawRectangle);
+            var drawRectangele = Shaders.OfType<IApplicableToDrawQuad>()
+                                        .Select(x => x.ComputeScreenSpaceDrawQuad(quad).AABBFloat)
+                                        .Aggregate(quad.AABBFloat, RectangleF.Union);
+
+            return Quad.FromRectangle(drawRectangele);
         }
 
         protected override DrawNode CreateDrawNode()


### PR DESCRIPTION
Fix issue #157.
Still have some issues need to be fixed, but guess should be OK enough to be merged.

What's done in this PR:
- make the interface.
- apply the interface and write the test case for it.
- apply the outline size in the karaoke sprite text transforms.
- now lyric sprite text will auto-calculate the draw size if change the shader or re-draw.