### PR TITLE
Implement SingleShaderBufferedDrawNode

### DIFF
--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
@@ -83,11 +83,12 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                 karaokeSpriteText.RightTextColour = Color4.White;
                 karaokeSpriteText.RightLyricTextShaders = new IShader[]
                 {
-                    GetShaderByType<OutlineShader>().With(s =>
-                    {
-                        s.Radius = 1;
-                        s.OutlineColour = Color4.Blue;
-                    }),
+                    // comment the shader out until lyric sprite text support multiple shader.
+                    // GetShaderByType<OutlineShader>().With(s =>
+                    // {
+                    //     s.Radius = 1;
+                    //     s.OutlineColour = Color4.Blue;
+                    // }),
                     new StepShader
                     {
                         Name = "Outline with rainbow effect",

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
@@ -43,11 +43,12 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
 
             AddStep("Apply rainbow shader", () => lyricSpriteText.Shaders = new IShader[]
             {
-                GetShaderByType<OutlineShader>().With(s =>
-                {
-                    s.Radius = 1;
-                    s.OutlineColour = Color4.Blue;
-                }),
+                // comment the shader out until lyric sprite text support multiple shader.
+                // GetShaderByType<OutlineShader>().With(s =>
+                // {
+                //     s.Radius = 1;
+                //     s.OutlineColour = Color4.Blue;
+                // }),
                 new StepShader
                 {
                     Name = "Outline with rainbow effect",

--- a/osu.Framework.Font/Graphics/IMultiShaderBufferedDrawable.cs
+++ b/osu.Framework.Font/Graphics/IMultiShaderBufferedDrawable.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics
 {
     public interface IMultiShaderBufferedDrawable : IBufferedDrawable
     {
-        IReadOnlyList<IShader> Shaders { get; set; }
+        IReadOnlyList<IShader> Shaders { get; }
     }
 }

--- a/osu.Framework.Font/Graphics/ISingleShaderBufferedDrawable.cs
+++ b/osu.Framework.Font/Graphics/ISingleShaderBufferedDrawable.cs
@@ -1,0 +1,12 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Shaders;
+
+namespace osu.Framework.Graphics
+{
+    public interface ISingleShaderBufferedDrawable : IBufferedDrawable
+    {
+        IShader Shader { get; }
+    }
+}

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
@@ -112,6 +112,7 @@ namespace osu.Framework.Graphics
 
                     for (int i = 0; i < stepShaders.Count; i++)
                     {
+                        // todo: it will cause the render issue if set the current and target shader into same shader.
                         renderShader(stepShaders[i], i == 0 ? current : target, target);
                     }
                 }

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNode.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics
 
         private readonly double loadTime;
 
-        public MultiShaderBufferedDrawNode(IBufferedDrawable source, DrawNode child, MultiShaderBufferedDrawNodeSharedData sharedData)
+        public MultiShaderBufferedDrawNode(IMultiShaderBufferedDrawable source, DrawNode child, MultiShaderBufferedDrawNodeSharedData sharedData)
             : base(source, child, sharedData)
         {
             loadTime = Source.Clock.CurrentTime;

--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
@@ -86,6 +86,7 @@ namespace osu.Framework.Graphics
                 if (frameBuffer.Texture == null)
                     return false;
 
+                // should not draw the step shader if there's no content.
                 if (shader is IStepShader stepShader)
                     return stepShader.StepShaders.Any() && stepShader.Draw;
 

--- a/osu.Framework.Font/Graphics/SingleShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/SingleShaderBufferedDrawNode.cs
@@ -1,0 +1,128 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics
+{
+    public class SingleShaderBufferedDrawNode : BufferedDrawNode
+    {
+        protected new ISingleShaderBufferedDrawable Source => (ISingleShaderBufferedDrawable)base.Source;
+
+        private readonly double loadTime;
+
+        public SingleShaderBufferedDrawNode(ISingleShaderBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData)
+            : base(source, child, sharedData)
+        {
+            loadTime = Source.Clock.CurrentTime;
+        }
+
+        protected override long GetDrawVersion()
+        {
+            // if contains shader that need to apply time, then need to force run populate contents in each frame.
+            if (ContainTimePropertyShader(Source.Shader))
+            {
+                ResetDrawVersion();
+            }
+
+            return base.GetDrawVersion();
+        }
+
+        protected static bool ContainTimePropertyShader(IShader shader)
+        {
+            switch (shader)
+            {
+                case IApplicableToCurrentTime _:
+                case IStepShader stepShader when stepShader.StepShaders.Any(s => s is IApplicableToCurrentTime):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        protected void ResetDrawVersion()
+        {
+            // todo : use better way to reset draw version.
+            var prop = typeof(BufferedDrawNodeSharedData).GetField("DrawVersion", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (prop == null)
+                throw new NullReferenceException();
+
+            prop.SetValue(SharedData, -1);
+        }
+
+        protected override void PopulateContents()
+        {
+            base.PopulateContents();
+
+            GLWrapper.PushScissorState(false);
+
+            drawFrameBuffer();
+
+            GLWrapper.PopScissorState();
+        }
+
+        protected override void DrawContents()
+        {
+            DrawFrameBuffer(SharedData.CurrentEffectBuffer, DrawRectangle, DrawColourInfo.Colour);
+        }
+
+        private void drawFrameBuffer()
+        {
+            var shader = Source.Shader;
+
+            switch (shader)
+            {
+                case null:
+                    return;
+
+                case IStepShader stepShader:
+                {
+                    var stepShaders = stepShader.StepShaders;
+
+                    foreach (var s in stepShaders)
+                    {
+                        renderShader(s);
+                    }
+
+                    break;
+                }
+
+                default:
+                    renderShader(shader);
+                    break;
+            }
+
+            void renderShader(IShader shader)
+            {
+                var current = SharedData.CurrentEffectBuffer;
+                var target = SharedData.GetNextEffectBuffer();
+
+                GLWrapper.SetBlend(BlendingParameters.None);
+
+                using (BindFrameBuffer(target))
+                {
+                    if (shader is ICustomizedShader customizedShader)
+                        customizedShader.ApplyValue(current);
+
+                    if (shader is IApplicableToCurrentTime clockShader)
+                    {
+                        var time = (float)(Source.Clock.CurrentTime - loadTime) / 1000;
+                        clockShader.ApplyCurrentTime(time);
+                    }
+
+                    shader.Bind();
+                    DrawFrameBuffer(current, new RectangleF(0, 0, current.Texture.Width, current.Texture.Height), ColourInfo.SingleColour(Color4.White));
+                    shader.Unbind();
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Sprites
     {
     }
 
-    public partial class KaraokeSpriteText<T> : CompositeDrawable, IMultiShaderBufferedDrawable, IHasRuby, IHasRomaji where T : LyricSpriteText, new()
+    public partial class KaraokeSpriteText<T> : CompositeDrawable, ISingleShaderBufferedDrawable, IHasRuby, IHasRomaji where T : LyricSpriteText, new()
     {
         private readonly MaskingContainer<T> frontLyricTextContainer;
         private readonly T frontLyricText;
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.Sprites
         private readonly T backLyricText;
 
         // todo: should have a better way to let user able to customize formats?
-        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(2);
 
         public IShader TextureShader { get; private set; }
         public IShader RoundedTextureShader { get; private set; }
@@ -130,11 +130,18 @@ namespace osu.Framework.Graphics.Sprites
                 shaders.Clear();
 
                 if (value != null)
+                {
+                    if (value.Count > 1)
+                        throw new NotSupportedException($"{nameof(LyricSpriteText)} does not support more than one shaders now.");
+
                     shaders.AddRange(value);
+                }
 
                 Invalidate(Invalidation.DrawNode);
             }
         }
+
+        public IShader Shader => Shaders.FirstOrDefault();
 
         public IReadOnlyList<IShader> LeftLyricTextShaders
         {

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
@@ -24,16 +24,16 @@ namespace osu.Framework.Graphics.Sprites
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.
         /// </summary>
-        protected class KaraokeSpriteTextShaderEffectDrawNode : MultiShaderBufferedDrawNode, ICompositeDrawNode
+        protected class KaraokeSpriteTextShaderEffectDrawNode : SingleShaderBufferedDrawNode, ICompositeDrawNode
         {
             protected new KaraokeSpriteText<T> Source => (KaraokeSpriteText<T>)base.Source;
 
             protected new CompositeDrawableDrawNode Child => (CompositeDrawableDrawNode)base.Child;
 
-            private IShader[] leftLyricShaders;
-            private IShader[] rightLyricShaders;
+            private IShader leftLyricShader;
+            private IShader rightLyricShader;
 
-            public KaraokeSpriteTextShaderEffectDrawNode(KaraokeSpriteText<T> source, MultiShaderBufferedDrawNodeSharedData sharedData)
+            public KaraokeSpriteTextShaderEffectDrawNode(KaraokeSpriteText<T> source, BufferedDrawNodeSharedData sharedData)
                 : base(source, new CompositeDrawableDrawNode(source), sharedData)
             {
             }
@@ -42,14 +42,14 @@ namespace osu.Framework.Graphics.Sprites
             {
                 base.ApplyState();
 
-                leftLyricShaders = Source.LeftLyricTextShaders.ToArray();
-                rightLyricShaders = Source.RightLyricTextShaders.ToArray();
+                leftLyricShader = Source.LeftLyricTextShaders.FirstOrDefault();
+                rightLyricShader = Source.RightLyricTextShaders.FirstOrDefault();
             }
 
             protected override long GetDrawVersion()
             {
                 // if contains shader that need to apply time, then need to force run populate contents in each frame.
-                if (ContainTimePropertyShader(leftLyricShaders) || ContainTimePropertyShader(rightLyricShaders))
+                if (ContainTimePropertyShader(leftLyricShader) || ContainTimePropertyShader(rightLyricShader))
                 {
                     ResetDrawVersion();
                 }

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -22,13 +22,13 @@ namespace osu.Framework.Graphics.Sprites
     /// <summary>
     /// A container for simple text rendering purposes. If more complex text rendering is required, use <see cref="TextFlowContainer"/> instead.
     /// </summary>
-    public partial class LyricSpriteText : Drawable, IMultiShaderBufferedDrawable, IHasLineBaseHeight, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>, IHasRuby, IHasRomaji
+    public partial class LyricSpriteText : Drawable, ISingleShaderBufferedDrawable, IHasLineBaseHeight, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>, IHasRuby, IHasRomaji
     {
         private const float default_text_size = 48;
         private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ' };
 
         // todo: should have a better way to let user able to customize formats?
-        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(2);
 
         [Resolved]
         private FontStore store { get; set; }
@@ -111,11 +111,18 @@ namespace osu.Framework.Graphics.Sprites
                 shaders.Clear();
 
                 if (value != null)
+                {
+                    if (value.Count > 1)
+                        throw new NotSupportedException($"{nameof(LyricSpriteText)} does not support more than one shaders now.");
+
                     shaders.AddRange(value);
+                }
 
                 Invalidate();
             }
         }
+
+        public IShader Shader => Shaders.FirstOrDefault();
 
         #endregion
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.Sprites
 
         #region frame buffer
 
-        public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
+        public DrawColourInfo? FrameBufferDrawColour => new DrawColourInfo(Color4.White);
 
         private Color4 backgroundColour = new Color4(0, 0, 0, 0);
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -69,8 +69,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 for (int i = 0; i < parts.Count; i++)
                 {
-                    // Note: should use white here because buffered container will change the colour.
-                    DrawQuad(parts[i].Texture, parts[i].DrawQuad, Colour4.White, vertexAction: vertexAction, inflationPercentage: parts[i].InflationPercentage);
+                    DrawQuad(parts[i].Texture, parts[i].DrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction, inflationPercentage: parts[i].InflationPercentage);
                 }
 
                 Shader.Unbind();

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -31,9 +31,9 @@ namespace osu.Framework.Graphics.Sprites
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.
         /// </summary>
-        protected class LyricSpriteTextShaderEffectDrawNode : MultiShaderBufferedDrawNode
+        protected class LyricSpriteTextShaderEffectDrawNode : SingleShaderBufferedDrawNode
         {
-            public LyricSpriteTextShaderEffectDrawNode(LyricSpriteText source, MultiShaderBufferedDrawNodeSharedData sharedData)
+            public LyricSpriteTextShaderEffectDrawNode(LyricSpriteText source, BufferedDrawNodeSharedData sharedData)
                 : base(source, new LyricSpriteTextDrawNode(source), sharedData)
             {
             }


### PR DESCRIPTION
Implement the issue #167
And found the reason of #159
.
What's done in this PR:
- Not expose setter in the `IMultiShaderBufferedDrawable` interface.
- Instead of always drawing white color in the `LyricSpriteTextDrawNode`, it should be better not to affect the `FrameBufferDrawColour` if lyric drawable color changed.
- Add single shader buffer draw node and relative interface.
- Switch the draw node base class from `MultiShaderBufferedDrawNode` into `SingleShaderBufferedDrawNode` in the `lyric sprite text` and `karaoke sprite text`.
- Fix the test case.