### PR TITLE
Make characters private in the lyric sprite text.

### DIFF
--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -1,0 +1,166 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Font.Tests.Helper;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Font.Tests.Visual.Sprites
+{
+    public class TestSceneLyricSpriteTextCharacterPosition : BackgroundGridTestScene
+    {
+        private readonly Box showSizeBox;
+        private readonly LyricSpriteText lyricSpriteText;
+
+        public TestSceneLyricSpriteTextCharacterPosition()
+        {
+            Child = new Container
+            {
+                AutoSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(2),
+                Children = new Drawable[]
+                {
+                    showSizeBox = new Box
+                    {
+                        Colour = Color4.Green
+                    },
+                    lyricSpriteText = new LyricSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = "カラオケ",
+                        Rubies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }),
+                        Romajies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }),
+                    },
+                }
+            };
+
+            AddLabel("Shader");
+
+            AddStep("Clear shader", () =>
+            {
+                lyricSpriteText.Shaders = null;
+            });
+
+            AddStep("Apply single shader", () =>
+            {
+                lyricSpriteText.Shaders = new[]
+                {
+                    GetShaderByType<OutlineShader>().With(s =>
+                    {
+                        s.Radius = 10;
+                        s.OutlineColour = Color4.Green;
+                    })
+                };
+            });
+
+            AddStep("Apply multiple shaders", () =>
+            {
+                lyricSpriteText.Shaders = new[]
+                {
+                    new StepShader
+                    {
+                        StepShaders = new ICustomizedShader[]
+                        {
+                            GetShaderByType<OutlineShader>().With(s =>
+                            {
+                                s.Radius = 10;
+                                s.OutlineColour = Color4.Blue;
+                            }),
+                            GetShaderByType<ShadowShader>().With(s =>
+                            {
+                                s.ShadowOffset = new Vector2(10);
+                                s.ShadowColour = Color4.Aqua;
+                            })
+                        }
+                    }
+                };
+            });
+        }
+
+        [TestCase(0, TextIndex.IndexState.Start, true)]
+        [TestCase(3, TextIndex.IndexState.End, true)]
+        [TestCase(-1, TextIndex.IndexState.End, false)]
+        [TestCase(4, TextIndex.IndexState.Start, false)]
+        public void TestGetTextIndexPosition(int index, TextIndex.IndexState state, bool valid)
+        {
+            prepareTestCase(() =>
+            {
+                var position = lyricSpriteText.GetTextIndexPosition(new TextIndex(index, state));
+                return new RectangleF(position, 20, 1, 64);
+            }, valid);
+        }
+
+        [TestCase(0, true)]
+        [TestCase(3, true)]
+        [TestCase(-1, false)]
+        [TestCase(4, false)]
+        public void TestGetCharacterRectangle(int index, bool valid)
+        {
+            prepareTestCase(() => lyricSpriteText.GetCharacterRectangle(index), valid);
+        }
+
+        [TestCase("[0,1]:か", true)]
+        [TestCase("[1,2]:ら", true)]
+        [TestCase("[2,3]:お", true)]
+        [TestCase("[3,4]:け", true)]
+        [TestCase("[-1,1]:か", false)]
+        [TestCase("[0,2]:か", false)]
+        [TestCase("[0,1]:?", false)]
+        public void TestGetRubyTagPosition(string rubyTag, bool valid)
+        {
+            prepareTestCase(() => lyricSpriteText.GetRubyTagPosition(TestCaseTagHelper.ParsePositionText(rubyTag)), valid);
+        }
+
+        [TestCase("[0,1]:ka", true)]
+        [TestCase("[1,2]:ra", true)]
+        [TestCase("[2,3]:o", true)]
+        [TestCase("[3,4]:ke", true)]
+        [TestCase("[-1,1]:ka", false)]
+        [TestCase("[0,2]:ka", false)]
+        [TestCase("[0,1]:?", false)]
+        public void TestGetRomajiTagPosition(string rubyTag, bool valid)
+        {
+            prepareTestCase(() => lyricSpriteText.GetRomajiTagPosition(TestCaseTagHelper.ParsePositionText(rubyTag)), valid);
+        }
+
+        private void prepareTestCase(Func<RectangleF> func, bool valid)
+        {
+            if (valid)
+            {
+                AddStep("Get the rectangle", () =>
+                {
+                    var rectangle = func();
+                    moveTheBox(rectangle);
+                });
+            }
+            else
+            {
+                AddStep("Oops", () =>
+                {
+                    Assert.Catch<ArgumentOutOfRangeException>(() =>
+                    {
+                        func();
+                    });
+                });
+            }
+
+            void moveTheBox(RectangleF rectangleF)
+            {
+                showSizeBox.Position = rectangleF.TopLeft;
+                showSizeBox.Size = rectangleF.Size;
+            }
+        }
+    }
+}

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Layout;
 using osuTK;
@@ -478,25 +477,6 @@ namespace osu.Framework.Graphics.Sprites
         }
 
         private float getCharacterPosition(TextIndex index)
-        {
-            var characterRectangle = getCharacterRectangle(index);
-            var computedRectangle = getComputeCharacterDrawRectangle(index.State, characterRectangle);
-            return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
-
-            RectangleF getCharacterRectangle(TextIndex textIndex)
-            {
-                var characters = textIndex.State == TextIndex.IndexState.Start ? frontLyricText.Characters : backLyricText.Characters;
-                return characters[textIndex.Index].DrawRectangle;
-            }
-
-            RectangleF getComputeCharacterDrawRectangle(TextIndex.IndexState state, RectangleF originalCharacterDrawRectangle)
-            {
-                // combine the rectangle to get the max value.
-                var lyricTextShaders = state == TextIndex.IndexState.Start ? LeftLyricTextShaders : RightLyricTextShaders;
-                return lyricTextShaders.OfType<IApplicableToCharacterSize>()
-                                       .Select(x => x.ComputeCharacterDrawRectangle(originalCharacterDrawRectangle))
-                                       .Aggregate(originalCharacterDrawRectangle, RectangleF.Union);
-            }
-        }
+            => index.State == TextIndex.IndexState.Start ? frontLyricText.GetTextIndexPosition(index) : backLyricText.GetTextIndexPosition(index);
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -143,12 +143,7 @@ namespace osu.Framework.Graphics.Sprites
 
         public float GetTextIndexPosition(TextIndex index)
         {
-            int charIndex = Math.Clamp(index.Index, 0, Text.Length - 1);
-            if (charIndex != index.Index)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            var characterRectangle = characters[charIndex].DrawRectangle;
-            var computedRectangle = getComputeCharacterDrawRectangle(characterRectangle);
+            var computedRectangle = GetCharacterRectangle(index.Index);
             return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
         }
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -152,6 +152,50 @@ namespace osu.Framework.Graphics.Sprites
             return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
         }
 
+        public RectangleF GetCharacterRectangle(int index)
+        {
+            int charIndex = Math.Clamp(index, 0, Text.Length - 1);
+            if (charIndex != index)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            var character = Characters[charIndex];
+            var drawRectangle = character.DrawRectangle;
+            return getComputeCharacterDrawRectangle(drawRectangle);
+        }
+
+        public RectangleF GetRubyTagPosition(PositionText rubyTag)
+        {
+            int rubyIndex = Rubies.ToList().IndexOf(rubyTag);
+            if (rubyIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(rubyIndex));
+
+            int startCharacterIndex = Text.Length + skinIndex(Rubies, rubyIndex);
+            int count = rubyTag.Text.Length;
+            var drawRectangle = Characters.ToList()
+                                          .GetRange(startCharacterIndex, count)
+                                          .Select(x => x.DrawRectangle)
+                                          .Aggregate(RectangleF.Union);
+            return getComputeCharacterDrawRectangle(drawRectangle);
+        }
+
+        public RectangleF GetRomajiTagPosition(PositionText romajiTag)
+        {
+            int romajiIndex = Romajies.ToList().IndexOf(romajiTag);
+            if (romajiIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(romajiIndex));
+
+            int startCharacterIndex = Text.Length + skinIndex(Rubies, Rubies.Count) + skinIndex(Romajies, romajiIndex);
+            int count = romajiTag.Text.Length;
+            var drawRectangle = Characters.ToList()
+                                          .GetRange(startCharacterIndex, count)
+                                          .Select(x => x.DrawRectangle)
+                                          .Aggregate(RectangleF.Union);
+            return getComputeCharacterDrawRectangle(drawRectangle);
+        }
+
+        private int skinIndex(IEnumerable<PositionText> positionTexts, int endIndex)
+            => positionTexts.Where((_, i) => i < endIndex).Sum(x => x.Text.Length);
+
         private RectangleF getComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle)
         {
             // combine the rectangle to get the max value.

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shaders;
 using osu.Framework.Layout;
 using osu.Framework.Text;
 using osuTK;
@@ -137,6 +139,25 @@ namespace osu.Framework.Graphics.Sprites
             }
 
             localScreenSpaceCache.Validate();
+        }
+
+        public float GetTextIndexPosition(TextIndex index)
+        {
+            int charIndex = Math.Clamp(index.Index, 0, Text.Length - 1);
+            if (charIndex != index.Index)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            var characterRectangle = Characters[charIndex].DrawRectangle;
+            var computedRectangle = getComputeCharacterDrawRectangle(characterRectangle);
+            return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
+        }
+
+        private RectangleF getComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle)
+        {
+            // combine the rectangle to get the max value.
+            return Shaders.OfType<IApplicableToCharacterSize>()
+                          .Select(x => x.ComputeCharacterDrawRectangle(originalCharacterDrawRectangle))
+                          .Aggregate(originalCharacterDrawRectangle, RectangleF.Union);
         }
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.Sprites
         /// <summary>
         /// The characters in local space.
         /// </summary>
-        public IReadOnlyList<TextBuilderGlyph> Characters
+        private IReadOnlyList<TextBuilderGlyph> characters
         {
             get
             {
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.Sprites
 
             Vector2 inflationAmount = DrawInfo.MatrixInverse.ExtractScale().Xy;
 
-            foreach (var character in Characters)
+            foreach (var character in characters)
             {
                 screenSpaceCharactersBacking.Add(new ScreenSpaceCharacterPart
                 {
@@ -147,7 +147,7 @@ namespace osu.Framework.Graphics.Sprites
             if (charIndex != index.Index)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            var characterRectangle = Characters[charIndex].DrawRectangle;
+            var characterRectangle = characters[charIndex].DrawRectangle;
             var computedRectangle = getComputeCharacterDrawRectangle(characterRectangle);
             return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
         }
@@ -158,7 +158,7 @@ namespace osu.Framework.Graphics.Sprites
             if (charIndex != index)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            var character = Characters[charIndex];
+            var character = characters[charIndex];
             var drawRectangle = character.DrawRectangle;
             return getComputeCharacterDrawRectangle(drawRectangle);
         }
@@ -171,7 +171,7 @@ namespace osu.Framework.Graphics.Sprites
 
             int startCharacterIndex = Text.Length + skinIndex(Rubies, rubyIndex);
             int count = rubyTag.Text.Length;
-            var drawRectangle = Characters.ToList()
+            var drawRectangle = characters.ToList()
                                           .GetRange(startCharacterIndex, count)
                                           .Select(x => x.DrawRectangle)
                                           .Aggregate(RectangleF.Union);
@@ -186,7 +186,7 @@ namespace osu.Framework.Graphics.Sprites
 
             int startCharacterIndex = Text.Length + skinIndex(Rubies, Rubies.Count) + skinIndex(Romajies, romajiIndex);
             int count = romajiTag.Text.Length;
-            var drawRectangle = Characters.ToList()
+            var drawRectangle = characters.ToList()
                                           .GetRange(startCharacterIndex, count)
                                           .Select(x => x.DrawRectangle)
                                           .Aggregate(RectangleF.Union);

--- a/osu.Framework.Font/Graphics/Sprites/PositionText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/PositionText.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Framework.Graphics.Sprites
 {
-    public struct PositionText
+    public struct PositionText : IEquatable<PositionText>
     {
         public PositionText(string text, int startIndex, int endIndex)
         {
@@ -17,5 +19,23 @@ namespace osu.Framework.Graphics.Sprites
         public int StartIndex { get; set; }
 
         public int EndIndex { get; set; }
+
+        public bool Equals(PositionText other)
+            => StartIndex == other.StartIndex && EndIndex == other.EndIndex && Text == other.Text;
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PositionText positionText)
+                return Equals(positionText);
+
+            // If compare object is not int or position text, then it's no need to be compared.
+            return false;
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+
+        public static bool operator ==(PositionText first, PositionText second) => first.Equals(second);
+
+        public static bool operator !=(PositionText first, PositionText second) => !first.Equals(second);
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/TextIndex.cs
+++ b/osu.Framework.Font/Graphics/Sprites/TextIndex.cs
@@ -41,10 +41,10 @@ namespace osu.Framework.Graphics.Sprites
 
         public override bool Equals(object obj)
         {
-            if (obj is TextIndex tone)
-                return Equals(tone);
+            if (obj is TextIndex textIndex)
+                return Equals(textIndex);
 
-            // If compare object is not int or tone, then it's no need to be compared.
+            // If compare object is not int or text index, then it's no need to be compared.
             return false;
         }
 


### PR DESCRIPTION
What's done in this PR:
- Let position text able to be compared.
- Make characters in the lyric sprite text be private.
- Should be able to get the main text, ruby and romaji char size in the lyric sprite text.
- Write the test scene to show the text size get in the lyric sprite text.