### PR TITLE
Implement shader scale interface.

### DIFF
--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -53,9 +53,9 @@ namespace osu.Framework.Font.Tests.Shaders
             const float pi = 3.14159265359f;
             double angle = 0.0f;
 
-            Console.WriteLine($"lowp float outlineAlpha(sampler2D tex, int radius, mediump vec2 texCoord, mediump vec2 texSize)");
+            Console.WriteLine($"lowp float outlineAlpha(sampler2D tex, float radius, mediump vec2 texCoord, mediump vec2 texSize)");
             Console.WriteLine("{");
-            Console.WriteLine("    mediump vec2 offset = mediump vec2(float(radius)) / texSize;");
+            Console.WriteLine("    mediump vec2 offset = mediump vec2(radius) / texSize;");
             Console.WriteLine("    lowp float alpha = 0.0;");
             Console.WriteLine();
 

--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
@@ -42,6 +43,30 @@ namespace osu.Framework.Font.Tests.Shaders
             Assert.AreEqual(expectedY, rectangle.Y);
             Assert.AreEqual(expectedWidth, rectangle.Width);
             Assert.AreEqual(expectedHeight, rectangle.Height);
+        }
+
+        [TestCase(32)]
+        public void CreateGetOutlineMethod(int samples)
+        {
+            // it's a script on creating const params in shader.
+
+            const float pi = 3.14159265359f;
+            double angle = 0.0f;
+
+            Console.WriteLine($"lowp float outlineAlpha(sampler2D tex, int radius, mediump vec2 texCoord, mediump vec2 texSize)");
+            Console.WriteLine("{");
+            Console.WriteLine("    mediump vec2 offset = mediump vec2(float(radius)) / texSize;");
+            Console.WriteLine("    lowp float alpha = 0.0;");
+            Console.WriteLine();
+
+            for (int i = 0; i < samples; i++)
+            {
+                angle += 1.0 / (samples / 2.0) * pi;
+                Console.WriteLine($"    alpha = max(alpha, texture2D(tex, texCoord - lowp vec2({Math.Sin(angle):N2}, {Math.Cos(angle):N2}) * offset).a);");
+            }
+
+            Console.WriteLine("    return alpha;");
+            Console.WriteLine("}");
         }
     }
 }

--- a/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
@@ -10,8 +10,8 @@ namespace osu.Framework.Font.Tests.Shaders
 {
     public class ShadowShaderTest
     {
-        private const float offset_x = 11;
-        private const float offset_y = 12;
+        private const float offset_x = 4;
+        private const float offset_y = 5;
 
         [TestCase(offset_x, 0, 5, 5, 10 + offset_x, 10)] // Offset right
         [TestCase(-offset_x, 0, 5 - offset_x, 5, 10 + offset_x, 10)] // Offset left

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Font.Tests.Shaders
         [Test]
         public void TestComputeCharacterDrawRectangle()
         {
-            const int outline_radius = 10;
+            const int outline_radius = 3;
             const int shadow_offset_x = 11;
             const int shadow_offset_y = 12;
 
@@ -42,7 +42,7 @@ namespace osu.Framework.Font.Tests.Shaders
         [Test]
         public void TestComputeScreenSpaceDrawQuad()
         {
-            const int outline_radius = 10;
+            const int outline_radius = 3;
             const int shadow_offset_x = 11;
             const int shadow_offset_y = 12;
 

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -14,8 +14,8 @@ namespace osu.Framework.Font.Tests.Shaders
         public void TestComputeCharacterDrawRectangle()
         {
             const int outline_radius = 3;
-            const int shadow_offset_x = 11;
-            const int shadow_offset_y = 12;
+            const int shadow_offset_x = 4;
+            const int shadow_offset_y = 5;
 
             var shader = new StepShader
             {
@@ -43,8 +43,8 @@ namespace osu.Framework.Font.Tests.Shaders
         public void TestComputeScreenSpaceDrawQuad()
         {
             const int outline_radius = 3;
-            const int shadow_offset_x = 11;
-            const int shadow_offset_y = 12;
+            const int shadow_offset_x = 4;
+            const int shadow_offset_y = 5;
 
             var shader = new StepShader
             {

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneOutlineShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneOutlineShader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -50,30 +49,6 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                     })
                 };
             });
-        }
-
-        [TestCase(32)]
-        public void CreateGetOutlineMethod(int samples)
-        {
-            // it's a script on creating const params in shader.
-
-            const float pi = 3.14159265359f;
-            double angle = 0.0f;
-
-            Console.WriteLine($"lowp float outlineAlpha(sampler2D tex, int radius, mediump vec2 texCoord, mediump vec2 texSize)");
-            Console.WriteLine("{");
-            Console.WriteLine("    mediump vec2 offset = mediump vec2(float(radius)) / texSize;");
-            Console.WriteLine("    lowp float alpha = 0.0;");
-            Console.WriteLine();
-
-            for (int i = 0; i < samples; i++)
-            {
-                angle += 1.0 / (samples / 2.0) * pi;
-                Console.WriteLine($"    alpha = max(alpha, texture2D(tex, texCoord - lowp vec2({Math.Sin(angle):N2}, {Math.Cos(angle):N2}) * offset).a);");
-            }
-
-            Console.WriteLine("    return alpha;");
-            Console.WriteLine("}");
         }
     }
 }

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShadowShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneShadowShader.cs
@@ -11,8 +11,8 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
 {
     public class TestSceneShadowShader : InternalShaderTestScene
     {
-        [TestCase(RED, "(10,10)")]
-        [TestCase(GREEN, "(-20,-20)")]
+        [TestCase(RED, "(3,3)")]
+        [TestCase(GREEN, "(-4,-4)")]
         [TestCase(BLUE, "(0,0)")]
         public void TestProperty(string colour, string offset)
         {

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneStepShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneStepShader.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                     GetShaderByType<ShadowShader>().With(s =>
                     {
                         s.ShadowColour = Color4.Red;
-                        s.ShadowOffset = new Vector2(30, 30);
+                        s.ShadowOffset = new Vector2(3);
                     })
                 }
             };

--- a/osu.Framework.Font.Tests/Visual/Shaders/TestSceneStepShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Shaders/TestSceneStepShader.cs
@@ -21,12 +21,12 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                 {
                     GetShaderByType<OutlineShader>().With(s =>
                     {
-                        s.Radius = 10;
+                        s.Radius = 3;
                         s.OutlineColour = Color4.Yellow;
                     }),
                     GetShaderByType<OutlineShader>().With(s =>
                     {
-                        s.Radius = 10;
+                        s.Radius = 3;
                         s.OutlineColour = Color4.Red;
                     })
                 }
@@ -61,7 +61,7 @@ namespace osu.Framework.Font.Tests.Visual.Shaders
                 {
                     GetShaderByType<OutlineShader>().With(s =>
                     {
-                        s.Radius = 10;
+                        s.Radius = 3;
                         s.OutlineColour = Color4.Yellow;
                     })
                 }

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         private const string right_outline_color = "#5932CC";
         private const string right_shadow_color = "#3D2D6B";
 
-        private const int outline_radius = 10;
+        private const int outline_radius = 3;
         private const int shadow_sizing = 10;
 
         private const double start_time = 1000;

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextTransforms.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         private const string right_shadow_color = "#3D2D6B";
 
         private const int outline_radius = 3;
-        private const int shadow_sizing = 10;
+        private const int shadow_sizing = 3;
 
         private const double start_time = 1000;
         private const double end_time = 5000;

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                 {
                     GetShaderByType<OutlineShader>().With(s =>
                     {
-                        s.Radius = 5;
+                        s.Radius = 2;
                         s.OutlineColour = Color4.Green;
                     })
                 };
@@ -96,7 +96,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                         {
                             GetShaderByType<OutlineShader>().With(s =>
                             {
-                                s.Radius = 10;
+                                s.Radius = 3;
                                 s.OutlineColour = Color4.White;
                             }),
                             GetShaderByType<RainbowShader>()

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                 {
                     GetShaderByType<OutlineShader>().With(s =>
                     {
-                        s.Radius = 10;
+                        s.Radius = 3;
                         s.OutlineColour = Color4.Green;
                     })
                 };
@@ -75,7 +75,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                         {
                             GetShaderByType<OutlineShader>().With(s =>
                             {
-                                s.Radius = 10;
+                                s.Radius = 3;
                                 s.OutlineColour = Color4.Blue;
                             }),
                             GetShaderByType<ShadowShader>().With(s =>

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                             }),
                             GetShaderByType<ShadowShader>().With(s =>
                             {
-                                s.ShadowOffset = new Vector2(10);
+                                s.ShadowOffset = new Vector2(2);
                                 s.ShadowColour = Color4.Aqua;
                             })
                         }

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
             {
                 GetShaderByType<OutlineShader>().With(s =>
                 {
-                    s.Radius = 10;
+                    s.Radius = 3;
                     s.OutlineColour = Color4.Green;
                 })
             });
@@ -56,7 +56,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                     {
                         GetShaderByType<OutlineShader>().With(s =>
                         {
-                            s.Radius = 10;
+                            s.Radius = 3;
                             s.OutlineColour = Color4.White;
                         }),
                         GetShaderByType<RainbowShader>()

--- a/osu.Framework.Font/Graphics/CustomizedShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/CustomizedShaderBufferedDrawNode.cs
@@ -28,8 +28,8 @@ namespace osu.Framework.Graphics
         {
             switch (shader)
             {
-                case IApplicableToCurrentTime _:
-                case IStepShader stepShader when stepShader.StepShaders.Any(s => s is IApplicableToCurrentTime):
+                case IHasCurrentTime _:
+                case IStepShader stepShader when stepShader.StepShaders.Any(s => s is IHasCurrentTime):
                     return true;
 
                 default:
@@ -65,14 +65,14 @@ namespace osu.Framework.Graphics
                     shader.GetUniform<float>(@"g_InflationPercentage").UpdateValue(ref localInflationAmount);
                 }
 
+                if (shader is IHasCurrentTime)
+                {
+                    var currentTime = (float)(Source.Clock.CurrentTime - loadTime) / 1000;
+                    shader.GetUniform<float>("g_Time").UpdateValue(ref currentTime);
+                }
+
                 if (shader is ICustomizedShader customizedShader)
                     customizedShader.ApplyValue();
-
-                if (shader is IApplicableToCurrentTime clockShader)
-                {
-                    var time = (float)(Source.Clock.CurrentTime - loadTime) / 1000;
-                    clockShader.ApplyCurrentTime(time);
-                }
 
                 shader.Bind();
                 DrawFrameBuffer(current, new RectangleF(0, 0, current.Texture.Width, current.Texture.Height), ColourInfo.SingleColour(Color4.White));

--- a/osu.Framework.Font/Graphics/CustomizedShaderBufferedDrawNode.cs
+++ b/osu.Framework.Font/Graphics/CustomizedShaderBufferedDrawNode.cs
@@ -59,6 +59,12 @@ namespace osu.Framework.Graphics
                     shader.GetUniform<Vector2>(@"g_TexSize").UpdateValue(ref size);
                 }
 
+                if (shader is IHasInflationPercentage)
+                {
+                    var localInflationAmount = DrawInfo.Matrix.ExtractScale().X;
+                    shader.GetUniform<float>(@"g_InflationPercentage").UpdateValue(ref localInflationAmount);
+                }
+
                 if (shader is ICustomizedShader customizedShader)
                     customizedShader.ApplyValue();
 

--- a/osu.Framework.Font/Graphics/Shaders/IHasCurrentTime.cs
+++ b/osu.Framework.Font/Graphics/Shaders/IHasCurrentTime.cs
@@ -3,8 +3,7 @@
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public interface IApplicableToCurrentTime
+    public interface IHasCurrentTime
     {
-        void ApplyCurrentTime(float currentTime);
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/IHasInflationPercentage.cs
+++ b/osu.Framework.Font/Graphics/Shaders/IHasInflationPercentage.cs
@@ -1,0 +1,9 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public interface IHasInflationPercentage
+    {
+    }
+}

--- a/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
@@ -8,13 +8,13 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class OutlineShader : InternalShader, IApplicableToCharacterSize, IApplicableToDrawQuad, IHasTextureSize
+    public class OutlineShader : InternalShader, IApplicableToCharacterSize, IApplicableToDrawQuad, IHasTextureSize, IHasInflationPercentage
     {
         public override string ShaderName => "Outline";
 
         public Color4 Colour { get; set; }
 
-        public int Radius { get; set; }
+        public float Radius { get; set; }
 
         public Color4 OutlineColour { get; set; }
 
@@ -23,8 +23,8 @@ namespace osu.Framework.Graphics.Shaders
             var colourMatrix = new Vector4(Colour.R, Colour.G, Colour.B, Colour.A);
             GetUniform<Vector4>(@"g_Colour").UpdateValue(ref colourMatrix);
 
-            var radius = Radius;
-            GetUniform<int>(@"g_Radius").UpdateValue(ref radius);
+            float radius = Radius;
+            GetUniform<float>(@"g_Radius").UpdateValue(ref radius);
 
             var outlineColourMatrix = new Vector4(OutlineColour.R, OutlineColour.G, OutlineColour.B, OutlineColour.A);
             GetUniform<Vector4>(@"g_OutlineColour").UpdateValue(ref outlineColourMatrix);

--- a/osu.Framework.Font/Graphics/Shaders/PixelShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/PixelShader.cs
@@ -5,7 +5,7 @@ using osuTK;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class PixelShader : InternalShader, IHasTextureSize
+    public class PixelShader : InternalShader, IHasTextureSize, IHasInflationPercentage
     {
         public override string ShaderName => "Pixel";
 

--- a/osu.Framework.Font/Graphics/Shaders/RainbowShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/RainbowShader.cs
@@ -5,7 +5,7 @@ using osuTK;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class RainbowShader : InternalShader, IApplicableToCurrentTime
+    public class RainbowShader : InternalShader, IHasCurrentTime
     {
         public override string ShaderName => "Rainbow";
 
@@ -41,11 +41,6 @@ namespace osu.Framework.Graphics.Shaders
 
             var mix = Mix;
             GetUniform<float>(@"g_Mix").UpdateValue(ref mix);
-        }
-
-        public void ApplyCurrentTime(float currentTime)
-        {
-            GetUniform<float>("g_Time").UpdateValue(ref currentTime);
         }
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/RepeatMovingBackgroundShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/RepeatMovingBackgroundShader.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class RepeatMovingBackgroundShader : InternalShader, IApplicableToCurrentTime, IHasTextureSize
+    public class RepeatMovingBackgroundShader : InternalShader, IHasCurrentTime, IHasTextureSize
     {
         public override string ShaderName => "RepeatMovingBackground";
 
@@ -49,11 +49,6 @@ namespace osu.Framework.Graphics.Shaders
 
             var mix = Math.Clamp(Mix, 0, 1);
             GetUniform<float>(@"g_Mix").UpdateValue(ref mix);
-        }
-
-        public void ApplyCurrentTime(float currentTime)
-        {
-            GetUniform<float>("g_Time").UpdateValue(ref currentTime);
         }
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class ShadowShader : InternalShader, IApplicableToDrawQuad, IHasTextureSize
+    public class ShadowShader : InternalShader, IApplicableToDrawQuad, IHasTextureSize, IHasInflationPercentage
     {
         public override string ShaderName => "Shadow";
 

--- a/osu.Framework.Font/Resources/Shaders/sh_Outline.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Outline.fs
@@ -6,12 +6,13 @@ uniform lowp sampler2D m_Sampler;
 
 uniform mediump vec2 g_TexSize;
 uniform vec4 g_Colour;
-uniform int g_Radius;
+uniform float g_Radius;
 uniform vec4 g_OutlineColour;
+uniform float g_InflationPercentage;
 
-lowp float outlineAlpha(sampler2D tex, int radius, mediump vec2 texCoord, mediump vec2 texSize)
+lowp float outlineAlpha(sampler2D tex, float radius, mediump vec2 texCoord, mediump vec2 texSize)
 {
-    mediump vec2 offset = mediump vec2(float(radius)) / texSize;
+    mediump vec2 offset = mediump vec2(radius) / texSize;
     lowp float alpha = 0.0;
 
     alpha = max(alpha, texture2D(tex, texCoord - lowp vec2(0.20, 0.98) * offset).a);
@@ -49,9 +50,9 @@ lowp float outlineAlpha(sampler2D tex, int radius, mediump vec2 texCoord, medium
     return alpha;
 }
 
-lowp vec4 outline(sampler2D tex, int radius, mediump vec2 texCoord, mediump vec2 texSize, mediump vec4 colour)
+lowp vec4 outline(sampler2D tex, float radius, mediump vec2 texCoord, mediump vec2 texSize, mediump vec4 colour)
 {
-	lowp float outlineAlpha = max(outlineAlpha(tex, radius, texCoord, texSize), outlineAlpha(tex, radius / 2, texCoord, texSize));
+	lowp float outlineAlpha = max(outlineAlpha(tex, radius, texCoord, texSize), outlineAlpha(tex, radius / 2.0, texCoord, texSize));
 	return mix(vec4(0.0), colour, outlineAlpha);
 }
 
@@ -59,7 +60,7 @@ void main(void)
 {
 	lowp vec4 sample = toSRGB(texture2D(m_Sampler, v_TexCoord));
 	lowp vec4 originColur = vec4(mix(sample.rgb, g_Colour.rgb, g_Colour.a), sample.a);
-	lowp vec4 outlineColour = outline(m_Sampler, g_Radius, v_TexCoord, g_TexSize, g_OutlineColour);
+	lowp vec4 outlineColour = outline(m_Sampler, g_Radius * g_InflationPercentage, v_TexCoord, g_TexSize, g_OutlineColour);
 
 	gl_FragColor = mix(outlineColour, originColur, originColur.a);
 }

--- a/osu.Framework.Font/Resources/Shaders/sh_Pixel.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Pixel.fs
@@ -7,10 +7,12 @@ uniform lowp sampler2D m_Sampler;
 
 uniform mediump vec2 g_TexSize;
 uniform mediump vec2 g_Size;
+uniform float g_InflationPercentage;
+
 
 void main(void) 
 { 
-	vec2 separaorParts = g_TexSize / g_Size;
+	vec2 separaorParts = g_TexSize / (g_Size * g_InflationPercentage);
 	vec2 uv = v_TexCoord;
 	uv = uv * separaorParts;
     uv = floor(uv);

--- a/osu.Framework.Font/Resources/Shaders/sh_Shadow.fs
+++ b/osu.Framework.Font/Resources/Shaders/sh_Shadow.fs
@@ -7,6 +7,7 @@ uniform lowp sampler2D m_Sampler;
 uniform mediump vec2 g_TexSize;
 uniform vec4 g_Colour;
 uniform vec2 g_Offset;
+uniform float g_InflationPercentage;
 
 lowp vec4 shadow(sampler2D tex, mediump vec2 texCoord, mediump vec2 texSize, mediump vec4 colour, mediump vec2 offset)
 {
@@ -16,6 +17,6 @@ lowp vec4 shadow(sampler2D tex, mediump vec2 texCoord, mediump vec2 texSize, med
 void main(void)
 {
 	lowp vec4 texture = toSRGB(texture2D(m_Sampler, v_TexCoord));
-	lowp vec4 shadow = shadow(m_Sampler, v_TexCoord, g_TexSize, g_Colour, g_Offset);
+	lowp vec4 shadow = shadow(m_Sampler, v_TexCoord, g_TexSize, g_Colour, g_Offset * g_InflationPercentage);
 	gl_FragColor = mix(shadow, texture, texture.a);
 }


### PR DESCRIPTION
Fix most of issue in the #173.

What's done in this PR:
- Implement interface for able to apply the scale info into shader.
- Apply the interface into outline, pixel and shadow shader.
- Because apply scale info might let outline size become larger in the looking, so adjust the outline and shadow offset value in all test cases.

Code-quality related:
- Move the generate outline shader method into outline shader text in the test case.
- IApplicableToCurrentTime -> IHasCurrentTime.