### PR TITLE
Fix sizing calculation issue in the shader.

### DIFF
--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -37,8 +37,7 @@ namespace osu.Framework.Font.Tests.Shaders
                 Radius = radius
             };
 
-            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
-            var rectangle = quad.AABBFloat;
+            var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
             Assert.AreEqual(expectedX, rectangle.X);
             Assert.AreEqual(expectedY, rectangle.Y);
             Assert.AreEqual(expectedWidth, rectangle.Width);

--- a/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
@@ -24,8 +24,7 @@ namespace osu.Framework.Font.Tests.Shaders
                 ShadowOffset = new Vector2(offsetX, offsetY)
             };
 
-            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
-            var rectangle = quad.AABBFloat;
+            var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
             Assert.AreEqual(expectedX, rectangle.X);
             Assert.AreEqual(expectedY, rectangle.Y);
             Assert.AreEqual(expectedWidth, rectangle.Width);

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -61,8 +61,7 @@ namespace osu.Framework.Font.Tests.Shaders
                 }
             };
 
-            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
-            var rectangle = quad.AABBFloat;
+            var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
             Assert.AreEqual(5 - outline_radius, rectangle.X);
             Assert.AreEqual(5 - outline_radius, rectangle.Y);
             Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_x, rectangle.Width);
@@ -86,8 +85,7 @@ namespace osu.Framework.Font.Tests.Shaders
         {
             var shader = new StepShader();
 
-            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
-            var rectangle = quad.AABBFloat;
+            var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
             Assert.AreEqual(5, rectangle.X);
             Assert.AreEqual(5, rectangle.Y);
             Assert.AreEqual(10, rectangle.Width);
@@ -123,8 +121,7 @@ namespace osu.Framework.Font.Tests.Shaders
                 }
             };
 
-            var quad = shader.ComputeScreenSpaceDrawQuad(new Quad(5, 5, 10, 10));
-            var rectangle = quad.AABBFloat;
+            var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
             Assert.AreEqual(5, rectangle.X);
             Assert.AreEqual(5, rectangle.Y);
             Assert.AreEqual(10, rectangle.Width);

--- a/osu.Framework.Font/Graphics/Shaders/IApplicableToDrawRectangle.cs
+++ b/osu.Framework.Font/Graphics/Shaders/IApplicableToDrawRectangle.cs
@@ -5,8 +5,8 @@ using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public interface IApplicableToDrawQuad
+    public interface IApplicableToDrawRectangle
     {
-        Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad);
+        RectangleF ComputeDrawRectangle(RectangleF originDrawRectangle);
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/OutlineShader.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class OutlineShader : InternalShader, IApplicableToCharacterSize, IApplicableToDrawQuad, IHasTextureSize, IHasInflationPercentage
+    public class OutlineShader : InternalShader, IApplicableToCharacterSize, IApplicableToDrawRectangle, IHasTextureSize, IHasInflationPercentage
     {
         public override string ShaderName => "Outline";
 
@@ -33,10 +33,7 @@ namespace osu.Framework.Graphics.Shaders
         public RectangleF ComputeCharacterDrawRectangle(RectangleF originalCharacterDrawRectangle)
             => originalCharacterDrawRectangle.Inflate(Math.Max(Radius, 0));
 
-        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad)
-        {
-            var rectangle = ComputeCharacterDrawRectangle(originDrawQuad.AABBFloat);
-            return Quad.FromRectangle(rectangle);
-        }
+        public RectangleF ComputeDrawRectangle(RectangleF originDrawRectangle)
+            => ComputeCharacterDrawRectangle(originDrawRectangle);
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ShadowShader.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class ShadowShader : InternalShader, IApplicableToDrawQuad, IHasTextureSize, IHasInflationPercentage
+    public class ShadowShader : InternalShader, IApplicableToDrawRectangle, IHasTextureSize, IHasInflationPercentage
     {
         public override string ShaderName => "Shadow";
 
@@ -25,17 +25,13 @@ namespace osu.Framework.Graphics.Shaders
             GetUniform<Vector2>(@"g_Offset").UpdateValue(ref shadowOffset);
         }
 
-        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad)
-        {
-            var rectangle = originDrawQuad.AABBFloat.Inflate(new MarginPadding
+        public RectangleF ComputeDrawRectangle(RectangleF originDrawRectangle)
+            => originDrawRectangle.Inflate(new MarginPadding
             {
                 Left = Math.Max(-ShadowOffset.X, 0),
                 Right = Math.Max(ShadowOffset.X, 0),
                 Top = Math.Max(-ShadowOffset.Y, 0),
                 Bottom = Math.Max(ShadowOffset.Y, 0),
             });
-
-            return Quad.FromRectangle(rectangle);
-        }
     }
 }

--- a/osu.Framework.Font/Graphics/Shaders/StepShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/StepShader.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class StepShader : IStepShader, IApplicableToCharacterSize, IApplicableToDrawQuad
+    public class StepShader : IStepShader, IApplicableToCharacterSize, IApplicableToDrawRectangle
     {
         public string Name { get; set; }
 
@@ -50,8 +50,8 @@ namespace osu.Framework.Graphics.Shaders
             StepShaders.OfType<IApplicableToCharacterSize>()
                        .Aggregate(originalCharacterDrawRectangle, (rectangle, shader) => shader.ComputeCharacterDrawRectangle(rectangle));
 
-        public Quad ComputeScreenSpaceDrawQuad(Quad originDrawQuad) =>
-            StepShaders.OfType<IApplicableToDrawQuad>()
-                       .Aggregate(originDrawQuad, (quad, shader) => shader.ComputeScreenSpaceDrawQuad(quad));
+        public RectangleF ComputeDrawRectangle(RectangleF originDrawRectangle) =>
+            StepShaders.OfType<IApplicableToDrawRectangle>()
+                       .Aggregate(originDrawRectangle, (quad, shader) => shader.ComputeDrawRectangle(quad));
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
@@ -12,17 +12,16 @@ namespace osu.Framework.Graphics.Sprites
     {
         protected override Quad ComputeScreenSpaceDrawQuad()
         {
-            var quad = ToScreenSpace(DrawRectangle);
-            var lyricSpriteTextDrawRectangle = LeftLyricTextShaders.Concat(RightLyricTextShaders).OfType<IApplicableToDrawQuad>()
-                                                                   .Select(x => x.ComputeScreenSpaceDrawQuad(quad).AABBFloat)
-                                                                   .Aggregate(quad.AABBFloat, RectangleF.Union);
+            var lyricSpriteTextDrawRectangle = LeftLyricTextShaders.Concat(RightLyricTextShaders).OfType<IApplicableToDrawRectangle>()
+                                                                   .Select(x => x.ComputeDrawRectangle(DrawRectangle))
+                                                                   .Aggregate(DrawRectangle, RectangleF.Union);
 
             // after union the size of left side and right side of the internal sprite text draw size, need to calculate the extra size in the karaoke sprite text itself.
-            var drawRectangle = Shaders.OfType<IApplicableToDrawQuad>()
-                                       .Select(x => x.ComputeScreenSpaceDrawQuad(quad).AABBFloat)
+            var drawRectangle = Shaders.OfType<IApplicableToDrawRectangle>()
+                                       .Select(x => x.ComputeDrawRectangle(lyricSpriteTextDrawRectangle))
                                        .Aggregate(lyricSpriteTextDrawRectangle, RectangleF.Union);
 
-            return Quad.FromRectangle(drawRectangle);
+            return ToScreenSpace(drawRectangle);
         }
 
         protected override DrawNode CreateDrawNode()

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -17,12 +17,11 @@ namespace osu.Framework.Graphics.Sprites
         protected override Quad ComputeScreenSpaceDrawQuad()
         {
             // make draw size become bigger (for not masking the shader).
-            var quad = ToScreenSpace(DrawRectangle);
-            var drawRectangle = Shaders.OfType<IApplicableToDrawQuad>()
-                                       .Select(x => x.ComputeScreenSpaceDrawQuad(quad).AABBFloat)
-                                       .Aggregate(quad.AABBFloat, RectangleF.Union);
+            var drawRectangle = Shaders.OfType<IApplicableToDrawRectangle>()
+                                       .Select(x => x.ComputeDrawRectangle(DrawRectangle))
+                                       .Aggregate(DrawRectangle, RectangleF.Union);
 
-            return Quad.FromRectangle(drawRectangle);
+            return ToScreenSpace(drawRectangle);
         }
 
         protected override DrawNode CreateDrawNode()


### PR DESCRIPTION
Finally can close #173.

What's done in this PR:
- `IApplicableToDrawQuad` -> `IApplicableToDrawRectangle`
- Should calculate the draw size first in the `KaraokeSpriteText` and `LyricSpriteText`.
- Fix remaining error in the test case.