### PR TITLE
Should re-calculate the transforms if change the shader in the karaoke sprite text.

### DIFF
--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteText.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteText.cs
@@ -1,11 +1,13 @@
-// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Font.Tests.Helper;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Font.Tests.Visual.Sprites
@@ -18,11 +20,14 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         {
             Child = karaokeSpriteText = new KaraokeSpriteText
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 Text = "カラオケ！",
                 Rubies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:か", "[2,3]:お" }),
                 Romajies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[1,2]:ra", "[3,4]:ke" }),
                 LeftTextColour = Color4.Green,
                 RightTextColour = Color4.Red,
+                Scale = new Vector2(2),
             };
         }
 

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -423,12 +423,21 @@ namespace osu.Framework.Graphics.Sprites
         {
             var result = base.OnInvalidate(invalidation, source);
 
-            if (!invalidation.HasFlag(Invalidation.Presence))
+            if (!invalidation.HasFlag(Invalidation.Layout))
                 return result;
 
             Schedule(RefreshStateTransforms);
 
             return true;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Because refresh state only triggered if some property changed.
+            // So we should make sure that it will be triggered at least once.
+            RefreshStateTransforms();
         }
 
         public virtual void RefreshStateTransforms()

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -149,7 +149,7 @@ namespace osu.Framework.Graphics.Sprites
             {
                 leftLyricText.Shaders = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -160,7 +160,7 @@ namespace osu.Framework.Graphics.Sprites
             {
                 rightLyricText.Shaders = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -176,7 +176,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.Text = value;
                 rightLyricText.Text = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -188,7 +188,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.Rubies = value;
                 rightLyricText.Rubies = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.Romajies = value;
                 rightLyricText.Romajies = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -216,7 +216,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.Font = value;
                 rightLyricText.Font = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -228,7 +228,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RubyFont = value;
                 rightLyricText.RubyFont = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -240,7 +240,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RomajiFont = value;
                 rightLyricText.RomajiFont = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -278,7 +278,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RubyAlignment = value;
                 rightLyricText.RubyAlignment = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -290,7 +290,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RomajiAlignment = value;
                 rightLyricText.RomajiAlignment = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -306,7 +306,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.Spacing = value;
                 rightLyricText.Spacing = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -318,7 +318,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RubySpacing = value;
                 rightLyricText.RubySpacing = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -330,7 +330,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RomajiSpacing = value;
                 rightLyricText.RomajiSpacing = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -346,7 +346,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RubyMargin = value;
                 rightLyricText.RubyMargin = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 
@@ -358,7 +358,7 @@ namespace osu.Framework.Graphics.Sprites
                 leftLyricText.RomajiMargin = value;
                 rightLyricText.RomajiMargin = value;
 
-                Invalidate(Invalidation.DrawNode);
+                Invalidate(Invalidation.Layout);
             }
         }
 


### PR DESCRIPTION
Closes issue #178

What's done in this PR:
- Make the karaoke text in the center in the test case.
- Adjust the test case to make it able to show the trigger transform count.
- Should trigger the transform to be re-calculate if shader, text, font, alignment and spacing changed.
- Reduce initial transform trigger count.