### PR TITLE
Should add center time-tag inside every input time-tag in the input list.

### DIFF
--- a/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
@@ -1,0 +1,27 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Font.Tests.Helper;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Font.Tests.Graphics.Sprites
+{
+    public class KaraokeSpriteTextTest
+    {
+        [TestCase(new[] { "[0,start]:500", "[1,start]:600", "[2,start]:1000", "[3,start]:1500" }, new[] { "[0,start]:500", "[1,start]:600", "[2,start]:1000", "[3,start]:1500" })] // there's no need to add the interpolation time-tags.
+        public void TestGetInterpolatedTimeTags(string[] timeTags, string[] expectedTimeTags)
+        {
+            var karaokeSpriteText = new KaraokeSpriteText
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+
+            var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
+            var actualInterpolatedTimeTags = karaokeSpriteText.GetInterpolatedTimeTags();
+
+            Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        }
+    }
+}

--- a/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
@@ -9,7 +9,28 @@ namespace osu.Framework.Font.Tests.Graphics.Sprites
 {
     public class KaraokeSpriteTextTest
     {
-        [TestCase(new[] { "[0,start]:500", "[1,start]:600", "[2,start]:1000", "[3,start]:1500" }, new[] { "[0,start]:500", "[1,start]:600", "[2,start]:1000", "[3,start]:1500" })] // there's no need to add the interpolation time-tags.
+        [TestCase(new[] { "[0,start]:500", "[0,end]:600" },
+            new[] { "[0,start]:500", "[0,end]:600" })] // there's no need to add the interpolation time-tags.
+        [TestCase(new[] { "[-1,start]:500", "[4,start]:600" },
+            new string[] { })] // will filter those out-of-range time-tags.
+        [TestCase(new[] { "[0,start]:500", "[1,start]:501" },
+            new[] { "[0,start]:500", "[1,start]:501" })] // there's no need to add the interpolation time-tags because timing is too small.
+        [TestCase(new[] { "[0,start]:500", "[2,start]:600" },
+            new[] { "[0,start]:500", "[1,end]:599", "[2,start]:600" })] // It's time to add the interpolation time-tags.
+        [TestCase(new[] { "[0,end]:500", "[1,end]:600" },
+            new[] { "[0,end]:500", "[1,start]:501", "[1,end]:600" })]
+        [TestCase(new[] { "[0,end]:500", "[2,start]:600" },
+            new[] { "[0,end]:500", "[1,start]:501", "[1,end]:599", "[2,start]:600" })]
+        [TestCase(new[] { "[0,end]:500", "[3,start]:600" },
+            new[] { "[0,end]:500", "[1,start]:501", "[2,end]:599", "[3,start]:600" })]
+        [TestCase(new[] { "[2,start]:500", "[0,start]:600" },
+            new[] { "[2,start]:500", "[1,end]:501", "[0,start]:600" })] // let's test some reverse state
+        [TestCase(new[] { "[1,end]:500", "[0,end]:600" },
+            new[] { "[1,end]:500", "[1,start]:599", "[0,end]:600" })]
+        [TestCase(new[] { "[2,start]:500", "[0,end]:600" },
+            new[] { "[2,start]:500", "[1,end]:501", "[1,start]:599", "[0,end]:600" })]
+        [TestCase(new[] { "[3,start]:500", "[0,end]:600" },
+            new[] { "[3,start]:500", "[2,end]:501", "[1,start]:599", "[0,end]:600" })]
         public void TestGetInterpolatedTimeTags(string[] timeTags, string[] expectedTimeTags)
         {
             var karaokeSpriteText = new KaraokeSpriteText

--- a/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
+++ b/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
@@ -29,5 +29,51 @@ namespace osu.Framework.Font.Tests.Utils
                 Assert.Throws<ArgumentException>(() => TextIndexUtils.Clamp(textIndex, minIndex, maxIndex));
             }
         }
+
+        [TestCase(0, TextIndex.IndexState.Start, 0)]
+        [TestCase(0, TextIndex.IndexState.End, 1)]
+        [TestCase(-1, TextIndex.IndexState.Start, -1)] // In utils not checking is index out of range
+        [TestCase(-1, TextIndex.IndexState.End, 0)]
+        public void TestToStringIndex(int index, TextIndex.IndexState state, int expected)
+        {
+            var textIndex = new TextIndex(index, state);
+
+            int actual = TextIndexUtils.ToStringIndex(textIndex);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(TextIndex.IndexState.Start, TextIndex.IndexState.End)]
+        [TestCase(TextIndex.IndexState.End, TextIndex.IndexState.Start)]
+        public void TestReverseState(TextIndex.IndexState state, TextIndex.IndexState expected)
+        {
+            var actual = TextIndexUtils.ReverseState(state);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(1, TextIndex.IndexState.End, 1, TextIndex.IndexState.Start)]
+        [TestCase(1, TextIndex.IndexState.Start, 0, TextIndex.IndexState.End)]
+        [TestCase(0, TextIndex.IndexState.Start, -1, TextIndex.IndexState.End)] // didn't care about negative value.
+        [TestCase(-1, TextIndex.IndexState.End, -1, TextIndex.IndexState.Start)] // didn't care about negative value.
+        public void TestGetPreviousIndex(int index, TextIndex.IndexState state, int expectedIndex, TextIndex.IndexState expectedState)
+        {
+            var textIndex = new TextIndex(index, state);
+
+            var expected = new TextIndex(expectedIndex, expectedState);
+            var actual = TextIndexUtils.GetPreviousIndex(textIndex);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(0, TextIndex.IndexState.Start, 0, TextIndex.IndexState.End)]
+        [TestCase(0, TextIndex.IndexState.End, 1, TextIndex.IndexState.Start)]
+        [TestCase(-1, TextIndex.IndexState.Start, -1, TextIndex.IndexState.End)] // didn't care about negative value.
+        [TestCase(-1, TextIndex.IndexState.End, 0, TextIndex.IndexState.Start)] // didn't care about negative value.
+        public void TestGetNextIndex(int index, TextIndex.IndexState state, int expectedIndex, TextIndex.IndexState expectedState)
+        {
+            var textIndex = new TextIndex(index, state);
+
+            var expected = new TextIndex(expectedIndex, expectedState);
+            var actual = TextIndexUtils.GetNextIndex(textIndex);
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -447,9 +447,7 @@ namespace osu.Framework.Graphics.Sprites
             rightLyricTextContainer.ClearTransforms();
 
             // filter valid time-tag with order.
-            var validTimeTag = TimeTags
-                               .Where(x => x.Value.Index >= 0 && x.Value.Index < Text.Length)
-                               .OrderBy(x => x.Key).ToArray();
+            var validTimeTag = GetInterpolatedTimeTags();
 
             // not initialize if no time-tag or text.
             var hasTimeTag = validTimeTag.Any();
@@ -487,6 +485,17 @@ namespace osu.Framework.Graphics.Sprites
                 // save current time-tag time for letting next time-tag able to calculate duration.
                 relativeTime = time;
             }
+        }
+
+        internal IReadOnlyDictionary<double, TextIndex> GetInterpolatedTimeTags()
+        {
+            var orderedTimeTags = TimeTags
+                                  .Where(x => x.Value.Index >= 0 && x.Value.Index < Text.Length)
+                                  .OrderBy(x => x.Key).ToArray();
+
+            // todo: do the algorithm.
+
+            return orderedTimeTags.ToDictionary(k => k.Key, v => v.Value);
         }
 
         private float getTextIndexPosition(TextIndex index)

--- a/osu.Framework.Font/Utils/TextIndexUtils.cs
+++ b/osu.Framework.Font/Utils/TextIndexUtils.cs
@@ -12,5 +12,32 @@ namespace osu.Framework.Utils
         {
             return new TextIndex(Math.Clamp(value.Index, minValue, maxValue), value.State);
         }
+
+        public static int ToStringIndex(TextIndex index)
+        {
+            if (index.State == TextIndex.IndexState.Start)
+                return index.Index;
+
+            return index.Index + 1;
+        }
+
+        public static TextIndex.IndexState ReverseState(TextIndex.IndexState state)
+        {
+            return state == TextIndex.IndexState.Start ? TextIndex.IndexState.End : TextIndex.IndexState.Start;
+        }
+
+        public static TextIndex GetPreviousIndex(TextIndex originIndex)
+        {
+            int previousIndex = ToStringIndex(originIndex) - 1;
+            var previousState = ReverseState(originIndex.State);
+            return new TextIndex(previousIndex, previousState);
+        }
+
+        public static TextIndex GetNextIndex(TextIndex originIndex)
+        {
+            int nextIndex = ToStringIndex(originIndex);
+            var nextState = ReverseState(originIndex.State);
+            return new TextIndex(nextIndex, nextState);
+        }
     }
 }

--- a/osu.Framework.Font/osu.Framework.Font.csproj
+++ b/osu.Framework.Font/osu.Framework.Font.csproj
@@ -32,4 +32,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>osu.Framework.Font.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes issue #163

What's done in this PR:
- Adjust the test project for able to let it test internal method.
- Add some utils copied from https://github.com/karaoke-dev/karaoke
- Implement the time-tag interpolation algorithm and add it into the test case.