### PR TITLE
Fix will cause error if trying to get romaji position with no ruby.

### DIFF
--- a/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Font.Tests.Helper;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Font.Tests.Graphics.Sprites
+{
+    public class LyricSpriteTextTest
+    {
+        [TestCase("カラオケ", "[0,1]:か", "[0,1]:か")]
+        [TestCase("カラオケ", "[3,4]:か", "[3,4]:か")]
+        [TestCase("カラオケ", "[-1,1]:か", "[0,1]:か")] // fix out of range issue.
+        [TestCase("カラオケ", "[0,5]:か", "[0,4]:か")]
+        [TestCase("カラオケ", "[1,0]:か", "[0,1]:か")] // fix the case that end index is small than start index.
+        [TestCase("カラオケ", "[0,0]:か", "[0,0]:か")] // will not fix if start and end index is same.
+        [TestCase("カラオケ", "[0,1]:", "[0,1]:")] // will not fix the case with no text.
+        [TestCase("", "[0,0]:か", "[0,0]:か")] // should be validate
+        [TestCase("", "[0,0]:か", "[0,0]:か")]
+        [TestCase("", "[-1,1]:か", "[0,0]:か")] // should give it a fix.
+        [TestCase("", "[-1,1]:か", "[0,0]:か")]
+        public void TestGetFixedPositionText(string lyric, string positionText, string fixedPositionText)
+        {
+            var expected = TestCaseTagHelper.ParsePositionText(fixedPositionText);
+            var actual = LyricSpriteText.GetFixedPositionText(TestCaseTagHelper.ParsePositionText(positionText), lyric);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Framework.Font.Tests/Helper/TestCaseTagHelper.cs
+++ b/osu.Framework.Font.Tests/Helper/TestCaseTagHelper.cs
@@ -34,12 +34,7 @@ namespace osu.Framework.Font.Tests.Helper
             var endIndex = int.Parse(result.Groups["end"].Value);
             var text = result.Groups["ruby"].Value;
 
-            return new PositionText
-            {
-                StartIndex = startIndex,
-                EndIndex = endIndex,
-                Text = text
-            };
+            return new PositionText(text, startIndex, endIndex);
         }
 
         /// <summary>

--- a/osu.Framework.Font.Tests/Text/PositionTextBuilderTest.cs
+++ b/osu.Framework.Font.Tests/Text/PositionTextBuilderTest.cs
@@ -84,12 +84,7 @@ namespace osu.Framework.Font.Tests.Text
         public void TestAddPositionTextHasChar(char c, bool equal)
         {
             var builder = new PositionTextBuilder(fontStore, normal_font, normal_font, characterList: characterList);
-            builder.AddText(new PositionText
-            {
-                StartIndex = 0,
-                EndIndex = 1,
-                Text = c.ToString()
-            });
+            builder.AddText(new PositionText(c.ToString(), 0, 1));
 
             var character = builder.Characters.LastOrDefault();
 
@@ -109,12 +104,7 @@ namespace osu.Framework.Font.Tests.Text
         public void TestAddPositionTextPosition(char c, float x, float y)
         {
             var builder = new PositionTextBuilder(fontStore, normal_font, normal_font, characterList: characterList);
-            builder.AddText(new PositionText
-            {
-                StartIndex = 0,
-                EndIndex = 1,
-                Text = c.ToString()
-            });
+            builder.AddText(new PositionText(c.ToString(), 0, 1));
 
             var character = builder.Characters.LastOrDefault();
             var topLeftPosition = character.DrawRectangle.TopLeft;

--- a/osu.Framework.Font.Tests/Text/PositionTextBuilderTest.cs
+++ b/osu.Framework.Font.Tests/Text/PositionTextBuilderTest.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Font.Tests.Text
         [TestCase('A', false)]
         public void TestAddPositionTextHasChar(char c, bool equal)
         {
-            var builder = new PositionTextBuilder(fontStore, normal_font, normal_font, characterList: characterList);
+            var builder = new PositionTextBuilder(fontStore, normal_font, characterList: characterList);
             builder.AddText(new PositionText(c.ToString(), 0, 1));
 
             var character = builder.Characters.LastOrDefault();
@@ -103,7 +103,7 @@ namespace osu.Framework.Font.Tests.Text
         [TestCase('ら', 9.0f, 6.5f)]
         public void TestAddPositionTextPosition(char c, float x, float y)
         {
-            var builder = new PositionTextBuilder(fontStore, normal_font, normal_font, characterList: characterList);
+            var builder = new PositionTextBuilder(fontStore, normal_font, characterList: characterList);
             builder.AddText(new PositionText(c.ToString(), 0, 1));
 
             var character = builder.Characters.LastOrDefault();

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -366,7 +366,7 @@ namespace osu.Framework.Graphics.Sprites
 
         #endregion
 
-        private readonly Dictionary<double, TextIndex> timeTags = new Dictionary<double, TextIndex>();
+        private readonly SortedDictionary<double, TextIndex> timeTags = new SortedDictionary<double, TextIndex>();
 
         public IReadOnlyDictionary<double, TextIndex> TimeTags
         {

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Graphics.Sprites
 
         private string displayedText => Text;
 
-        private IReadOnlyList<PositionText> rubies;
+        private readonly List<PositionText> rubies = new List<PositionText>();
 
         /// <summary>
         /// Gets or sets the ruby text to be displayed.
@@ -169,13 +169,18 @@ namespace osu.Framework.Graphics.Sprites
             get => rubies;
             set
             {
-                rubies = filterValidValues(value);
+                rubies.Clear();
+
+                if (value != null)
+                {
+                    rubies.AddRange(value);
+                }
 
                 invalidate(true);
             }
         }
 
-        private IReadOnlyList<PositionText> romajies;
+        private readonly List<PositionText> romajies = new List<PositionText>();
 
         /// <summary>
         /// Gets or sets the romaji text to be displayed.
@@ -185,17 +190,15 @@ namespace osu.Framework.Graphics.Sprites
             get => romajies;
             set
             {
-                romajies = filterValidValues(value);
+                romajies.Clear();
+
+                if (value != null)
+                {
+                    romajies.AddRange(value);
+                }
 
                 invalidate(true);
             }
-        }
-
-        private IReadOnlyList<PositionText> filterValidValues(IEnumerable<PositionText> texts)
-        {
-            return texts?.Where(positionText => Math.Min(positionText.StartIndex, positionText.EndIndex) >= 0
-                                                && Math.Max(positionText.StartIndex, positionText.EndIndex) <= text.Length
-                                                && positionText.EndIndex > positionText.StartIndex).ToArray();
         }
 
         #endregion
@@ -689,8 +692,8 @@ namespace osu.Framework.Graphics.Sprites
         {
             var excludeCharacters = FixedWidthExcludeCharacters ?? default_never_fixed_width_characters;
 
-            var rubyHeight = ReserveRubyHeight || (Rubies?.Any() ?? false) ? RubyFont.Size : 0;
-            var romajiHeight = ReserveRomajiHeight || (Romajies?.Any() ?? false) ? RomajiFont.Size : 0;
+            var rubyHeight = ReserveRubyHeight || Rubies.Any() ? RubyFont.Size : 0;
+            var romajiHeight = ReserveRomajiHeight || Romajies.Any() ? RomajiFont.Size : 0;
             var startOffset = new Vector2(Padding.Left, Padding.Top + rubyHeight);
             var spacing = Spacing + new Vector2(0, rubyHeight + romajiHeight);
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -717,14 +717,14 @@ namespace osu.Framework.Graphics.Sprites
         protected virtual PositionTextBuilder CreateRubyTextBuilder(ITexturedGlyphLookupStore store)
         {
             const int builder_max_width = int.MaxValue;
-            return new PositionTextBuilder(store, Font, RubyFont, builder_max_width, UseFullGlyphHeight,
+            return new PositionTextBuilder(store, RubyFont, builder_max_width, UseFullGlyphHeight,
                 new Vector2(0, -rubyMargin), rubySpacing, charactersBacking, FixedWidthExcludeCharacters, FallbackCharacter, FixedWidthReferenceCharacter, RelativePosition.Top, rubyAlignment);
         }
 
         protected virtual PositionTextBuilder CreateRomajiTextBuilder(ITexturedGlyphLookupStore store)
         {
             const int builder_max_width = int.MaxValue;
-            return new PositionTextBuilder(store, Font, RomajiFont, builder_max_width, UseFullGlyphHeight,
+            return new PositionTextBuilder(store, RomajiFont, builder_max_width, UseFullGlyphHeight,
                 new Vector2(0, romajiMargin), romajiSpacing, charactersBacking, FixedWidthExcludeCharacters, FallbackCharacter, FixedWidthReferenceCharacter, RelativePosition.Bottom, romajiAlignment);
         }
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -66,16 +66,19 @@ namespace osu.Framework.Graphics.Sprites
                 textBuilder.AddText(displayedText);
                 textBounds = textBuilder.Bounds;
 
-                if (rubies.Any())
+                var fixedRubies = getFixedPositionText(rubies, displayedText);
+                var fixedRomajies = getFixedPositionText(romajies, displayedText);
+
+                if (fixedRubies.Any())
                 {
                     var rubyTextBuilder = CreateRubyTextBuilder(store);
-                    rubies.ForEach(x => rubyTextBuilder.AddText(x));
+                    fixedRubies.ForEach(x => rubyTextBuilder.AddText(x));
                 }
 
-                if (romajies.Any())
+                if (fixedRomajies.Any())
                 {
                     var romajiTextBuilder = CreateRomajiTextBuilder(store);
-                    romajies.ForEach(x => romajiTextBuilder.AddText(x));
+                    fixedRomajies.ForEach(x => romajiTextBuilder.AddText(x));
                 }
             }
             finally
@@ -93,6 +96,19 @@ namespace osu.Framework.Graphics.Sprites
 
                 charactersCache.Validate();
             }
+
+            static List<PositionText> getFixedPositionText(IEnumerable<PositionText> positionTexts, string lyricText)
+                => positionTexts
+                   .Where(x => !string.IsNullOrEmpty(x.Text))
+                   .Select(x => GetFixedPositionText(x, lyricText))
+                   .ToList();
+        }
+
+        internal static PositionText GetFixedPositionText(PositionText positionText, string lyricText)
+        {
+            var startIndex = Math.Clamp(positionText.StartIndex, 0, lyricText.Length);
+            var endIndex = Math.Clamp(positionText.EndIndex, 0, lyricText.Length);
+            return new PositionText(positionText.Text, Math.Min(startIndex, endIndex), Math.Max(startIndex, endIndex));
         }
 
         private readonly LayoutValue parentScreenSpaceCache = new LayoutValue(Invalidation.DrawSize | Invalidation.Presence | Invalidation.DrawInfo, InvalidationSource.Parent);

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Layout;
@@ -67,13 +66,13 @@ namespace osu.Framework.Graphics.Sprites
                 textBuilder.AddText(displayedText);
                 textBounds = textBuilder.Bounds;
 
-                if (rubies?.Any() ?? false)
+                if (rubies.Any())
                 {
                     var rubyTextBuilder = CreateRubyTextBuilder(store);
                     rubies.ForEach(x => rubyTextBuilder.AddText(x));
                 }
 
-                if (romajies?.Any() ?? false)
+                if (romajies.Any())
                 {
                     var romajiTextBuilder = CreateRomajiTextBuilder(store);
                     romajies.ForEach(x => romajiTextBuilder.AddText(x));
@@ -86,7 +85,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 if (requiresAutoSizedHeight)
                 {
-                    var romajiHeight = ReserveRomajiHeight || (Romajies?.Any() ?? false) ? RomajiFont.Size : 0;
+                    var romajiHeight = ReserveRomajiHeight || Romajies.Any() ? RomajiFont.Size : 0;
                     base.Height = textBounds.Y + romajiHeight + Padding.Bottom;
                 }
 

--- a/osu.Framework.Font/Graphics/Sprites/PositionText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/PositionText.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace osu.Framework.Graphics.Sprites
 {
-    public struct PositionText : IEquatable<PositionText>
+    public readonly struct PositionText : IEquatable<PositionText>
     {
         public PositionText(string text, int startIndex, int endIndex)
         {
@@ -14,11 +14,11 @@ namespace osu.Framework.Graphics.Sprites
             EndIndex = endIndex;
         }
 
-        public string Text { get; set; }
+        public string Text { get; }
 
-        public int StartIndex { get; set; }
+        public int StartIndex { get; }
 
-        public int EndIndex { get; set; }
+        public int EndIndex { get; }
 
         public bool Equals(PositionText other)
             => StartIndex == other.StartIndex && EndIndex == other.EndIndex && Text == other.Text;

--- a/osu.Framework.Font/Text/PositionTextBuilder.cs
+++ b/osu.Framework.Font/Text/PositionTextBuilder.cs
@@ -12,12 +12,11 @@ namespace osu.Framework.Text
 {
     public class PositionTextBuilder : TextBuilder
     {
-        private readonly char fallbackCharacter;
         private readonly ITexturedGlyphLookupStore store;
-        private readonly FontUsage mainTextFont;
         private readonly FontUsage font;
         private readonly Vector2 startOffset;
         private readonly Vector2 spacing;
+        private readonly char fallbackCharacter;
 
         private readonly RelativePosition relativePosition;
         private readonly LyricTextAlignment alignment;
@@ -26,7 +25,6 @@ namespace osu.Framework.Text
         /// Creates a new <see cref="TextBuilder"/>.
         /// </summary>
         /// <param name="store">The store from which glyphs are to be retrieved from.</param>
-        /// <param name="mainTextFont">The main text's font.<paramref name="store"/>.</param>
         /// <param name="font">The font to use for glyph lookups from <paramref name="store"/>.</param>
         /// <param name="useFontSizeAsHeight">True to use the provided <see cref="font"/> size as the height for each line. False if the height of each individual glyph should be used.</param>
         /// <param name="startOffset">The offset at which characters should begin being added at.</param>
@@ -38,7 +36,7 @@ namespace osu.Framework.Text
         /// <param name="fixedWidthReferenceCharacter">The character to use to calculate the fixed width width. Defaults to 'm'.</param>
         /// <param name="relativePosition">Should be added into top or bottom.</param>
         /// <param name="alignment">Lyric text alignment.</param>
-        public PositionTextBuilder(ITexturedGlyphLookupStore store, FontUsage mainTextFont, FontUsage font, float maxWidth = int.MaxValue, bool useFontSizeAsHeight = true,
+        public PositionTextBuilder(ITexturedGlyphLookupStore store, FontUsage font, float maxWidth = int.MaxValue, bool useFontSizeAsHeight = true,
                                    Vector2 startOffset = default,
                                    Vector2 spacing = default, List<TextBuilderGlyph> characterList = null, char[] neverFixedWidthCharacters = null,
                                    char fallbackCharacter = '?', char fixedWidthReferenceCharacter = 'm', RelativePosition relativePosition = RelativePosition.Top,
@@ -46,7 +44,6 @@ namespace osu.Framework.Text
             : base(store, font, maxWidth, useFontSizeAsHeight, startOffset, spacing, characterList, neverFixedWidthCharacters, fallbackCharacter, fixedWidthReferenceCharacter)
         {
             this.store = store;
-            this.mainTextFont = mainTextFont;
             this.font = font;
             this.startOffset = startOffset;
             this.spacing = spacing;


### PR DESCRIPTION
Closes issue #193
Should prevent rubies and romajies become null.

What's done in this PR:
- make rubies and romajies not able to be null.
- move the filter step until computeCharacters.

Extra done:
- Make the position text readonly.
- There's no need to add the main font into position text font builder.
- Using sortable dictionary to make sure that the time-tags are always sorted(see now internal children in the osu-framework did).
