### PR TITLE
Should be able to get the full-size of the character.

### DIFF
--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -39,9 +39,9 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Text = "カラオケ",
-                        Rubies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }),
-                        Romajies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }),
+                        Text = "カラオケ－",
+                        Rubies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け", "[4,5]:－" }),
+                        Romajies = TestCaseTagHelper.ParseParsePositionTexts(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke", "[4,5]:yo" }),
                     },
                 }
             };
@@ -92,7 +92,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase(0, TextIndex.IndexState.Start, true)]
         [TestCase(3, TextIndex.IndexState.End, true)]
         [TestCase(-1, TextIndex.IndexState.End, false)]
-        [TestCase(4, TextIndex.IndexState.Start, false)]
+        [TestCase(5, TextIndex.IndexState.Start, false)]
         public void TestGetTextIndexPosition(int index, TextIndex.IndexState state, bool valid)
         {
             prepareTestCase(() =>
@@ -105,7 +105,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase(0, true)]
         [TestCase(3, true)]
         [TestCase(-1, false)]
-        [TestCase(4, false)]
+        [TestCase(5, false)]
         public void TestGetCharacterRectangle(int index, bool valid)
         {
             prepareTestCase(() => lyricSpriteText.GetCharacterRectangle(index), valid);
@@ -115,6 +115,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase("[1,2]:ら", true)]
         [TestCase("[2,3]:お", true)]
         [TestCase("[3,4]:け", true)]
+        [TestCase("[4,5]:－", true)]
         [TestCase("[-1,1]:か", false)]
         [TestCase("[0,2]:か", false)]
         [TestCase("[0,1]:?", false)]
@@ -127,6 +128,7 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase("[1,2]:ra", true)]
         [TestCase("[2,3]:o", true)]
         [TestCase("[3,4]:ke", true)]
+        [TestCase("[4,5]:yo", true)]
         [TestCase("[-1,1]:ka", false)]
         [TestCase("[0,2]:ka", false)]
         [TestCase("[0,1]:?", false)]

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -162,18 +162,18 @@ namespace osu.Framework.Graphics.Sprites
             return index.State == TextIndex.IndexState.Start ? computedRectangle.Left : computedRectangle.Right;
         }
 
-        public RectangleF GetCharacterRectangle(int index)
+        public RectangleF GetCharacterRectangle(int index, bool drawSizeOnly = false)
         {
             int charIndex = Math.Clamp(index, 0, Text.Length - 1);
             if (charIndex != index)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
             var character = characters[charIndex];
-            var drawRectangle = character.DrawRectangle;
+            var drawRectangle = getCharacterRectangle(character, drawSizeOnly);
             return getComputeCharacterDrawRectangle(drawRectangle);
         }
 
-        public RectangleF GetRubyTagPosition(PositionText rubyTag)
+        public RectangleF GetRubyTagPosition(PositionText rubyTag, bool drawSizeOnly = false)
         {
             int rubyIndex = Rubies.ToList().IndexOf(rubyTag);
             if (rubyIndex < 0)
@@ -183,12 +183,12 @@ namespace osu.Framework.Graphics.Sprites
             int count = rubyTag.Text.Length;
             var drawRectangle = characters.ToList()
                                           .GetRange(startCharacterIndex, count)
-                                          .Select(x => x.DrawRectangle)
+                                          .Select(x => getCharacterRectangle(x, drawSizeOnly))
                                           .Aggregate(RectangleF.Union);
             return getComputeCharacterDrawRectangle(drawRectangle);
         }
 
-        public RectangleF GetRomajiTagPosition(PositionText romajiTag)
+        public RectangleF GetRomajiTagPosition(PositionText romajiTag, bool drawSizeOnly = false)
         {
             int romajiIndex = Romajies.ToList().IndexOf(romajiTag);
             if (romajiIndex < 0)
@@ -198,9 +198,24 @@ namespace osu.Framework.Graphics.Sprites
             int count = romajiTag.Text.Length;
             var drawRectangle = characters.ToList()
                                           .GetRange(startCharacterIndex, count)
-                                          .Select(x => x.DrawRectangle)
+                                          .Select(x => getCharacterRectangle(x, drawSizeOnly))
                                           .Aggregate(RectangleF.Union);
             return getComputeCharacterDrawRectangle(drawRectangle);
+        }
+
+        private static RectangleF getCharacterRectangle(TextBuilderGlyph character, bool drawSizeOnly)
+        {
+            if (drawSizeOnly)
+                return character.DrawRectangle;
+
+            // todo: should get the real value.
+            var topReduce = character.Baseline * 0.3f;
+            var bottomIncrease = character.Baseline * 0.2f;
+            return character.DrawRectangle.Inflate(new MarginPadding
+            {
+                Top = character.YOffset - topReduce,
+                Bottom = character.Baseline - character.Height - character.YOffset + bottomIncrease,
+            });
         }
 
         private int skinIndex(IEnumerable<PositionText> positionTexts, int endIndex)


### PR DESCRIPTION
It's a way to fix issue #194 without having something called "GetTimeTagPosition" because it'a weird in the `LyricSpriteText`.

Also, `getCharacterRectangle` in the `LyricSpriteText` use the tricky way to calculate the size.
Should fix that eventually.