### PR TITLE
Use temp way to fix the karaoke sprite text not showing in some graphic cards.

### DIFF
--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -22,10 +22,10 @@ namespace osu.Framework.Graphics.Sprites
     {
         internal const double INTERPOLATION_TIMING = 1;
 
-        private readonly MaskingContainer<T> leftLyricTextContainer;
+        private readonly Container<T> leftLyricTextContainer;
         private readonly T leftLyricText;
 
-        private readonly MaskingContainer<T> rightLyricTextContainer;
+        private readonly Container<T> rightLyricTextContainer;
         private readonly T rightLyricText;
 
         // todo: should have a better way to let user able to customize formats?
@@ -39,22 +39,22 @@ namespace osu.Framework.Graphics.Sprites
             AutoSizeAxes = Axes.Both;
             InternalChildren = new Drawable[]
             {
-                rightLyricTextContainer = new MaskingContainer<T>
+                rightLyricTextContainer = new Container<T>
                 {
                     AutoSizeAxes = Axes.Y,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    MaskingEdges = Edges.Left,
+                    Masking = true,
                     Child = rightLyricText = new T
                     {
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                     }
                 },
-                leftLyricTextContainer = new MaskingContainer<T>
+                leftLyricTextContainer = new Container<T>
                 {
                     AutoSizeAxes = Axes.Y,
-                    MaskingEdges = Edges.Right,
+                    Masking = true,
                     Child = leftLyricText = new T(),
                 }
             };


### PR DESCRIPTION
It's a temp way to fix karaoke sprite text now showing due to #199
Because masking container has render issue in some graphic cards, so using container with masking effect instead.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/9100368/177792666-7a446701-5622-4058-8cce-e4d619bd9e39.png">
And seems it works fine even with no masking container.