### PR TITLE
Remove the restriction and use the multiple shader draw node.

### DIFF
--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneKaraokeSpriteTextWithShader.cs
@@ -84,12 +84,11 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                 karaokeSpriteText.RightTextColour = Color4.White;
                 karaokeSpriteText.RightLyricTextShaders = new IShader[]
                 {
-                    // comment the shader out until lyric sprite text support multiple shader.
-                    // GetShaderByType<OutlineShader>().With(s =>
-                    // {
-                    //     s.Radius = 1;
-                    //     s.OutlineColour = Color4.Blue;
-                    // }),
+                    GetShaderByType<OutlineShader>().With(s =>
+                    {
+                        s.Radius = 1;
+                        s.OutlineColour = Color4.Blue;
+                    }),
                     new StepShader
                     {
                         Name = "Outline with rainbow effect",

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextWithShader.cs
@@ -44,12 +44,11 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
 
             AddStep("Apply rainbow shader", () => lyricSpriteText.Shaders = new IShader[]
             {
-                // comment the shader out until lyric sprite text support multiple shader.
-                // GetShaderByType<OutlineShader>().With(s =>
-                // {
-                //     s.Radius = 1;
-                //     s.OutlineColour = Color4.Blue;
-                // }),
+                GetShaderByType<OutlineShader>().With(s =>
+                {
+                    s.Radius = 1;
+                    s.OutlineColour = Color4.Blue;
+                }),
                 new StepShader
                 {
                     Name = "Outline with rainbow effect",

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -135,8 +134,6 @@ namespace osu.Framework.Graphics.Sprites
                 Invalidate(Invalidation.DrawNode);
             }
         }
-
-        public IShader? Shader => Shaders.FirstOrDefault();
 
         public IReadOnlyList<IShader> LeftLyricTextShaders
         {

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.Sprites
     {
     }
 
-    public partial class KaraokeSpriteText<T> : CompositeDrawable, ISingleShaderBufferedDrawable, IHasRuby, IHasRomaji where T : LyricSpriteText, new()
+    public partial class KaraokeSpriteText<T> : CompositeDrawable, IMultiShaderBufferedDrawable, IHasRuby, IHasRomaji where T : LyricSpriteText, new()
     {
         internal const double INTERPOLATION_TIMING = 1;
 
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Sprites
         private readonly T rightLyricText;
 
         // todo: should have a better way to let user able to customize formats?
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(2);
+        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
 
         public IShader TextureShader { get; private set; } = null!;
         public IShader RoundedTextureShader { get; private set; } = null!;
@@ -129,9 +129,6 @@ namespace osu.Framework.Graphics.Sprites
             set
             {
                 shaders.Clear();
-
-                if (value.Count > 1)
-                    throw new NotSupportedException($"{nameof(LyricSpriteText)} does not support more than one shaders now.");
 
                 shaders.AddRange(value);
 

--- a/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/KaraokeSpriteText_DrawNode.cs
@@ -30,16 +30,16 @@ namespace osu.Framework.Graphics.Sprites
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.
         /// </summary>
-        protected class KaraokeSpriteTextShaderEffectDrawNode : SingleShaderBufferedDrawNode, ICompositeDrawNode
+        protected class KaraokeSpriteTextShaderEffectDrawNode : MultiShaderBufferedDrawNode, ICompositeDrawNode
         {
             protected new KaraokeSpriteText<T> Source => (KaraokeSpriteText<T>)base.Source;
 
             protected new CompositeDrawableDrawNode Child => (CompositeDrawableDrawNode)base.Child;
 
-            private IShader? leftLyricShader;
-            private IShader? rightLyricShader;
+            private IShader[] leftLyricShaders = null!;
+            private IShader[] rightLyricShaders = null!;
 
-            public KaraokeSpriteTextShaderEffectDrawNode(KaraokeSpriteText<T> source, BufferedDrawNodeSharedData sharedData)
+            public KaraokeSpriteTextShaderEffectDrawNode(KaraokeSpriteText<T> source, MultiShaderBufferedDrawNodeSharedData sharedData)
                 : base(source, new CompositeDrawableDrawNode(source), sharedData)
             {
             }
@@ -48,15 +48,15 @@ namespace osu.Framework.Graphics.Sprites
             {
                 base.ApplyState();
 
-                leftLyricShader = Source.LeftLyricTextShaders.FirstOrDefault();
-                rightLyricShader = Source.RightLyricTextShaders.FirstOrDefault();
+                leftLyricShaders = Source.LeftLyricTextShaders.ToArray();
+                rightLyricShaders = Source.RightLyricTextShaders.ToArray();
             }
 
             protected override long GetDrawVersion()
             {
                 // if contains shader that need to apply time, then need to force run populate contents in each frame.
-                var leftLyricShaderRequestDraw = leftLyricShader != null && ContainTimePropertyShader(leftLyricShader);
-                var rightLyricShaderRequestDraw = rightLyricShader != null && ContainTimePropertyShader(rightLyricShader);
+                var leftLyricShaderRequestDraw = leftLyricShaders.Any(ContainTimePropertyShader);
+                var rightLyricShaderRequestDraw = rightLyricShaders.Any(ContainTimePropertyShader);
 
                 if (leftLyricShaderRequestDraw || rightLyricShaderRequestDraw)
                 {

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -117,8 +116,6 @@ namespace osu.Framework.Graphics.Sprites
                 Invalidate();
             }
         }
-
-        public IShader? Shader => Shaders.FirstOrDefault();
 
         #endregion
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText.cs
@@ -22,13 +22,13 @@ namespace osu.Framework.Graphics.Sprites
     /// <summary>
     /// A container for simple text rendering purposes. If more complex text rendering is required, use <see cref="TextFlowContainer"/> instead.
     /// </summary>
-    public partial class LyricSpriteText : Drawable, ISingleShaderBufferedDrawable, IHasLineBaseHeight, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>, IHasRuby, IHasRomaji
+    public partial class LyricSpriteText : Drawable, IMultiShaderBufferedDrawable, IHasLineBaseHeight, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>, IHasRuby, IHasRomaji
     {
         private const float default_text_size = 48;
         private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ' };
 
         // todo: should have a better way to let user able to customize formats?
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(2);
+        private readonly MultiShaderBufferedDrawNodeSharedData sharedData = new MultiShaderBufferedDrawNodeSharedData();
 
         [Resolved, AllowNull]
         private FontStore store { get; set; }
@@ -111,9 +111,6 @@ namespace osu.Framework.Graphics.Sprites
             set
             {
                 shaders.Clear();
-
-                if (value.Count > 1)
-                    throw new NotSupportedException($"{nameof(LyricSpriteText)} does not support more than one shaders now.");
 
                 shaders.AddRange(value);
 

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_DrawNode.cs
@@ -29,9 +29,9 @@ namespace osu.Framework.Graphics.Sprites
         /// <summary>
         /// <see cref="BufferedDrawNode"/> to apply <see cref="IShader"/>.
         /// </summary>
-        protected class LyricSpriteTextShaderEffectDrawNode : SingleShaderBufferedDrawNode
+        protected class LyricSpriteTextShaderEffectDrawNode : MultiShaderBufferedDrawNode
         {
-            public LyricSpriteTextShaderEffectDrawNode(LyricSpriteText source, BufferedDrawNodeSharedData sharedData)
+            public LyricSpriteTextShaderEffectDrawNode(LyricSpriteText source, MultiShaderBufferedDrawNodeSharedData sharedData)
                 : base(source, new LyricSpriteTextDrawNode(source), sharedData)
             {
             }


### PR DESCRIPTION
Because seems there's no GC issue if using the `MultiShaderBufferedDrawNode` with the latest o!f.
So it's time to replace all `SingleShaderBufferedDrawNode` usage.

First step of #159 and it's the revert PR of #169.

Note that this PR should not be merged until tagged release version passed.