### PR TITLE
Fix cannot get the ruby/romaji text's position if there's no text in the position text class.

### DIFF
--- a/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Font.Tests.Graphics.Sprites
     public class LyricSpriteTextTest
     {
         [TestCase("カラオケ", new[] { "[0,1]:か" }, new[] { "[0,1]:か" })]
-        [TestCase("カラオケ", new[] { "[0,1]:", "[0,1]:" }, new string[] { })] // will filter those empty text time-tags.
+        [TestCase("カラオケ", new[] { "[0,1]:" }, new[] { "[0,1]: " })] // for able to get the empty ruby/romaji position text's position, will make the empty text with spacing instead.
         [TestCase("カラオケ", new[] { "[0,1]:か", "[0,1]:か" }, new[] { "[0,1]:か" })] // will filter the duplicated
         [TestCase("カラオケ", new[] { "[0,1]:か", "[0,1]:ら" }, new[] { "[0,1]:か", "[0,1]:ら" })] // will not filter even if index are same.
         [TestCase("カラオケ", new[] { "[0,1]:か", "[1,0]:か" }, new[] { "[0,1]:か" })] // will give it a fix and filter the duplicated.
@@ -27,7 +27,7 @@ namespace osu.Framework.Font.Tests.Graphics.Sprites
         [TestCase("カラオケ", "[0,5]:か", "[0,4]:か")]
         [TestCase("カラオケ", "[1,0]:か", "[0,1]:か")] // fix the case that end index is small than start index.
         [TestCase("カラオケ", "[0,0]:か", "[0,0]:か")] // will not fix if start and end index is same.
-        [TestCase("カラオケ", "[0,1]:", "[0,1]:")] // will not fix the case with no text.
+        [TestCase("カラオケ", "[0,1]:", "[0,1]: ")] // for able to get the empty ruby/romaji position text's position, will make the empty text with spacing instead.
         [TestCase("", "[0,0]:か", "[0,0]:か")] // should be validate
         [TestCase("", "[0,0]:か", "[0,0]:か")]
         [TestCase("", "[-1,1]:か", "[0,0]:か")] // should give it a fix.

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -40,8 +40,8 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Text = "カラオケyo－",
-                        Rubies = TestCaseTagHelper.ParsePositionTexts(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け", "[4,5]:－" }),
-                        Romajies = TestCaseTagHelper.ParsePositionTexts(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke", "[4,5]:yo" }),
+                        Rubies = TestCaseTagHelper.ParsePositionTexts(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け", "[4,5]:－", "[4,5]:" }),
+                        Romajies = TestCaseTagHelper.ParsePositionTexts(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke", "[4,5]:yo", "[4,5]:" }),
                     },
                 }
             };
@@ -116,7 +116,8 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase("[2,3]:お", true)]
         [TestCase("[3,4]:け", true)]
         [TestCase("[4,5]:－", true)]
-        [TestCase("[-1,1]:か", false)]
+        [TestCase("[4,5]:", true)] // Should be able to get the ruby/romaji text position even if text is empty.
+        [TestCase("[-1,1]:か", true)] // will be fixed into "[0,1]:か"
         [TestCase("[0,2]:か", false)]
         [TestCase("[0,1]:?", false)]
         public void TestGetRubyTagDrawRectangle(string rubyTag, bool valid)
@@ -129,7 +130,8 @@ namespace osu.Framework.Font.Tests.Visual.Sprites
         [TestCase("[2,3]:o", true)]
         [TestCase("[3,4]:ke", true)]
         [TestCase("[4,5]:yo", true)]
-        [TestCase("[-1,1]:ka", false)]
+        [TestCase("[4,5]:", true)] // Should be able to get the ruby/romaji text position even if text is empty.
+        [TestCase("[-1,1]:ka", true)] // will be fixed into "[0,1]:ka"
         [TestCase("[0,2]:ka", false)]
         [TestCase("[0,1]:?", false)]
         public void TestGetRomajiTagDrawRectangle(string rubyTag, bool valid)

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -383,8 +383,9 @@ namespace osu.Framework.Graphics.Sprites
 
         public RectangleF GetRubyTagDrawRectangle(PositionText rubyTag, bool drawSizeOnly = false)
         {
-            if (!rubyCharacters.TryGetValue(rubyTag, out var glyphs))
-                throw new ArgumentOutOfRangeException(nameof(rubyTag));
+            var fixedRubyTag = GetFixedPositionText(rubyTag, displayedText);
+            if (!rubyCharacters.TryGetValue(fixedRubyTag, out var glyphs))
+                throw new ArgumentOutOfRangeException(nameof(fixedRubyTag));
 
             var drawRectangle = glyphs.Select(x => drawSizeOnly ? x.DrawRectangle : TextBuilderGlyphUtils.GetCharacterSizeRectangle(x))
                                       .Aggregate(RectangleF.Union);
@@ -393,8 +394,9 @@ namespace osu.Framework.Graphics.Sprites
 
         public RectangleF GetRomajiTagDrawRectangle(PositionText romajiTag, bool drawSizeOnly = false)
         {
-            if (!romajiCharacters.TryGetValue(romajiTag, out var glyphs))
-                throw new ArgumentOutOfRangeException(nameof(romajiTag));
+            var fixedRomajiTag = GetFixedPositionText(romajiTag, displayedText);
+            if (!romajiCharacters.TryGetValue(fixedRomajiTag, out var glyphs))
+                throw new ArgumentOutOfRangeException(nameof(fixedRomajiTag));
 
             var drawRectangle = glyphs.Select(x => drawSizeOnly ? x.DrawRectangle : TextBuilderGlyphUtils.GetCharacterSizeRectangle(x))
                                       .Aggregate(RectangleF.Union);

--- a/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
+++ b/osu.Framework.Font/Graphics/Sprites/LyricSpriteText_Characters.cs
@@ -285,7 +285,6 @@ namespace osu.Framework.Graphics.Sprites
 
         internal static List<PositionText> GetFixedPositionTexts(IEnumerable<PositionText> positionTexts, string lyricText)
             => positionTexts
-               .Where(x => !string.IsNullOrEmpty(x.Text))
                .Select(x => GetFixedPositionText(x, lyricText))
                .Distinct()
                .ToList();
@@ -294,7 +293,8 @@ namespace osu.Framework.Graphics.Sprites
         {
             var startIndex = Math.Clamp(positionText.StartIndex, 0, lyricText.Length);
             var endIndex = Math.Clamp(positionText.EndIndex, 0, lyricText.Length);
-            return new PositionText(positionText.Text, Math.Min(startIndex, endIndex), Math.Max(startIndex, endIndex));
+            var text = string.IsNullOrEmpty(positionText.Text) ? " " : positionText.Text;
+            return new PositionText(text, Math.Min(startIndex, endIndex), Math.Max(startIndex, endIndex));
         }
 
         #endregion


### PR DESCRIPTION
Fix the issue in the https://github.com/karaoke-dev/karaoke/issues/1732
Need to make sure that position text should always be able to get the position even if there's no text inside.
