### PR TITLE
Add CLAUDE.md documenting the dependency-update workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# osu.Framework.KaraokeFont
+
+Unofficial osu!framework extension for extra font/text effects (outline, shadow, step shaders). Single desktop target (net8.0): `osu.Framework.Font` (library) + `osu.Framework.Font.Tests` (NUnit + visual test browser).
+
+## Updating dependencies
+
+This is a recurring task ("update the important packages, fix any test failures, one commit per category"). Follow this playbook — it encodes real breakage found while doing this by hand.
+
+### 1. Commit grouping from `.github/dependabot.yml`
+
+- **osu-related** group: `ppy.osu.Framework`, `ppy.osu.Game.Resources` — bump together, one commit.
+- Everything else (`Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`) is ungrouped — one commit each, matching how dependabot PRs land individually for these.
+
+Check with `dotnet list <csproj> package --outdated` per project (`dotnet list package --outdated` doesn't work directly on a solution/slnf-less repo layout here, but this repo has no `.slnf` — just build/restore at the repo root or per-csproj).
+
+### 2. Cross-check versions against `ppy/osu-framework` before trusting "latest"
+
+This repo depends directly on `ppy.osu.Framework`, so a "latest" bump can be a large jump (e.g. a full year of upstream releases). Before assuming a compile error is *your* bug:
+
+- Search upstream for the removed/changed symbol: `gh api "search/code?q=repo:ppy/osu-framework+filename:<Name>.cs"` to find where a type now lives, then `gh api "repos/ppy/osu-framework/commits?path=<file>"` to read *why* it changed (the commit message usually explains whether there's a real replacement or the old member was already dead).
+- Example hit from 2025.604.1 → 2026.629.0: `IShader.GetUniform<T>()` was removed (`osu.Framework/Graphics/Shaders/IShader.cs`). The upstream removal commit explained the method had been non-functional since `GlobalPropertyManager` was deleted years earlier — so the fix was deleting the matching dead passthrough in `ICustomizedShader`/`CustomizedShader`/`StepShader` (which already just threw `NotSupportedException` in `StepShader`, confirming nothing real depended on it), not finding a replacement API.
+- For `NUnit`/`NUnit3TestAdapter`/`Microsoft.NET.Test.Sdk`, this repo's own dependabot history tracks NuGet's latest independently of `ppy/osu-framework` (which pins much older test-tooling versions upstream) — keep following latest for these three.
+
+### 3. NUnit 3 → 4 major bump breaks classic `Assert.*` calls
+
+NUnit 4 removed the classic assertion methods (`Assert.AreEqual`, `AreNotEqual`, `Throws<T>(...)`, `Catch<T>(...)`) from the `Assert` class — they now live under `NUnit.Framework.Legacy.ClassicAssert` (separate namespace/DLL). Two migration paths; **use the constraint model** (what upstream NUnit recommends, and what was done here), not the `ClassicAssert` shim:
+
+```csharp
+Assert.AreEqual(expected, actual);        // ->  Assert.That(actual, Is.EqualTo(expected));
+Assert.AreNotEqual(expected, actual);     // ->  Assert.That(actual, Is.Not.EqualTo(expected));
+Assert.Throws<TEx>(() => Code());         // ->  Assert.That((Action)(() => Code()), Throws.TypeOf<TEx>());
+Assert.Catch<TEx>(() => Code());          // ->  Assert.That((Action)(() => Code()), Throws.InstanceOf<TEx>());
+```
+
+Gotcha: `Assert.That(() => ..., constraint)` is **ambiguous** (`CS0121`) between the `TestDelegate` and `Action` overloads when the argument is a bare lambda — NUnit kept both overloads and their signatures collide. Cast the lambda explicitly: `(Action)(() => ...)`. (`(TestDelegate)(...)` also compiles but is itself marked `[Obsolete]` — use `Action`.)
+
+If a repo already targets NUnit 4 (check the `.csproj` before assuming this migration is needed — not every repo in this org is still on NUnit 3), this step is a no-op.
+
+### 4. Local verification checklist
+
+```
+dotnet restore
+dotnet build            # 0 warnings / 0 errors is the bar — CI treats this repo's build as the test gate
+dotnet test             # run the full suite, confirm N/N passing, not just "build succeeded"
+dotnet list package --outdated   # run again after all bumps — should report nothing left outdated
+                                   # (aside from anything intentionally skipped, see section 2)
+```
+
+### 5. Committing and PR workflow
+
+- One commit per dependabot group/category (section 1), each with build+test passing before moving to the next.
+- Branch from `origin/master` (single fork/remote setup here, simpler than `osu-framework-microphone`), push, `gh pr create --repo andy840119/osu-framework-font --base master --head <branch>`.
+- If CI doesn't run on the PR, check `gh api repos/<owner>/<repo>/actions/permissions` — Actions can simply be disabled on a personal fork (`"enabled": false`), which is a repo-settings problem, not a workflow-file problem. Confirm the workflow YAML itself is correct before concluding CI is broken.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,9 @@ dotnet list package --outdated   # run again after all bumps — should report n
 ### 5. Committing and PR workflow
 
 - One commit per dependabot group/category (section 1), each with build+test passing before moving to the next.
-- Branch from `origin/master` (single fork/remote setup here, simpler than `osu-framework-microphone`), push, `gh pr create --repo andy840119/osu-framework-font --base master --head <branch>`.
+- **This repo has two remotes — check `git remote -v` before opening a PR, don't assume `origin` is the target:**
+  - `karaoke` → `karaoke-dev/osu-framework-font` — **this is the canonical upstream repo. PRs go here.**
+  - `origin` → `andy840119/osu-framework-font` — a personal fork/mirror. A PR opened against this one is easy to merge into the wrong place by mistake (it happened once — see PRs #183/#184, which were merged into the fork and then had to be re-opened against `karaoke-dev/osu-framework-font` as new PRs).
+  - Confirm which is which with `gh api repos/karaoke-dev/osu-framework-font --jq .permissions` (push access implies it's a legitimate target) rather than guessing from remote name alone — org names have changed before (`osu-karaoke` → `karaoke-dev` in the sibling `osu-framework-microphone` repo, which redirects automatically).
+- Branch from `karaoke/master` (`git fetch karaoke master` first), push to `karaoke`, then `gh pr create --repo karaoke-dev/osu-framework-font --base master --head <branch>`. Do **not** default to `origin`/`andy840119/osu-framework-font` unless the user explicitly asks for that fork specifically.
 - If CI doesn't run on the PR, check `gh api repos/<owner>/<repo>/actions/permissions` — Actions can simply be disabled on a personal fork (`"enabled": false`), which is a repo-settings problem, not a workflow-file problem. Confirm the workflow YAML itself is correct before concluding CI is broken.

--- a/osu.Framework.Font.Tests/Extensions/RectangleFExtensionsTest.cs
+++ b/osu.Framework.Font.Tests/Extensions/RectangleFExtensionsTest.cs
@@ -20,9 +20,9 @@ public class RectangleFExtensionsTest
         var rectangle = new RectangleF(10, 10, 20, 10);
         var target = rectangle.Scale(scale, origin);
 
-        Assert.AreEqual(target.X, x);
-        Assert.AreEqual(target.Y, y);
-        Assert.AreEqual(target.Width, width);
-        Assert.AreEqual(target.Height, height);
+        Assert.That(x, Is.EqualTo(target.X));
+        Assert.That(y, Is.EqualTo(target.Y));
+        Assert.That(width, Is.EqualTo(target.Width));
+        Assert.That(height, Is.EqualTo(target.Height));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
@@ -18,7 +18,7 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetInTheRangeTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags), "カラオケ");
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 
     [TestCase(new[] { "[0,start]:500", "[0,end]:600" },
@@ -38,7 +38,7 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetNonDuplicatedTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags));
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 
     [TestCase(new[] { "[0,start]:500", "[0,end]:600" },
@@ -68,6 +68,6 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetInterpolatedTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags));
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
@@ -18,7 +18,7 @@ public class LyricSpriteTextTest
     {
         var expected = TestCaseTagHelper.ParsePositionTexts(fixedPositionTexts);
         var actual = LyricSpriteText.GetFixedPositionTexts(TestCaseTagHelper.ParsePositionTexts(positionTexts), lyric);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase("カラオケ", "[0]:か", "[0]:か")]
@@ -35,6 +35,6 @@ public class LyricSpriteTextTest
     {
         var expected = fixedPositionText != null ? TestCaseTagHelper.ParsePositionText(fixedPositionText) : default(PositionText?);
         var actual = LyricSpriteText.GetFixedPositionText(TestCaseTagHelper.ParsePositionText(positionText), lyric);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/TextIndexTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/TextIndexTest.cs
@@ -14,7 +14,7 @@ public class TextIndexTest
     [TestCase("-1,start")]
     public void TestOperatorEqual(string textIndex1)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), TestCaseTextIndexHelper.ParseTextIndex(textIndex1));
+        Assert.That(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1)));
     }
 
     [TestCase("-1,start", "1,start")]
@@ -25,7 +25,7 @@ public class TextIndexTest
     [TestCase("-2,end", "-2,start")]
     public void TestOperatorNotEqual(string textIndex1, string textIndex2)
     {
-        Assert.AreNotEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), TestCaseTextIndexHelper.ParseTextIndex(textIndex2));
+        Assert.That(TestCaseTextIndexHelper.ParseTextIndex(textIndex2), Is.Not.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1)));
     }
 
     [TestCase("1,start", "0,start", true)]
@@ -34,7 +34,7 @@ public class TextIndexTest
     [TestCase("1,start", "1,end", false)]
     public void TestOperatorGreater(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) > TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) > TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("1,start", "0,start", true)]
@@ -43,7 +43,7 @@ public class TextIndexTest
     [TestCase("1,start", "1,end", false)]
     public void TestOperatorGreaterOrEqual(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) >= TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) >= TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("-1,start", "0,start", true)]
@@ -52,7 +52,7 @@ public class TextIndexTest
     [TestCase("-1,start", "-2,end", false)]
     public void TestOperatorLess(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) < TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) < TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("-1,start", "0,start", true)]
@@ -61,6 +61,6 @@ public class TextIndexTest
     [TestCase("-1,start", "-2,end", false)]
     public void TestOperatorLessOrEqual(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) <= TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) <= TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 }

--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -21,10 +21,10 @@ public class OutlineShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 
     [TestCase(10, -5, -5, 30, 30)]
@@ -38,10 +38,10 @@ public class OutlineShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 
     [TestCase(32)]

--- a/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
@@ -25,9 +25,9 @@ public class ShadowShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 }

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -33,10 +33,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5 - outline_radius, rectangle.X);
-        Assert.AreEqual(5 - outline_radius, rectangle.Y);
-        Assert.AreEqual(10 + outline_radius * 2, rectangle.Width);
-        Assert.AreEqual(10 + outline_radius * 2, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Y, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Width, Is.EqualTo(10 + outline_radius * 2));
+        Assert.That(rectangle.Height, Is.EqualTo(10 + outline_radius * 2));
     }
 
     [Test]
@@ -62,10 +62,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5 - outline_radius, rectangle.X);
-        Assert.AreEqual(5 - outline_radius, rectangle.Y);
-        Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_x, rectangle.Width);
-        Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_y, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Y, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Width, Is.EqualTo(10 + outline_radius * 2 + shadow_offset_x));
+        Assert.That(rectangle.Height, Is.EqualTo(10 + outline_radius * 2 + shadow_offset_y));
     }
 
     [Test]
@@ -74,10 +74,10 @@ public class StepShaderTest
         var shader = new StepShader();
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -86,10 +86,10 @@ public class StepShaderTest
         var shader = new StepShader();
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -104,10 +104,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -122,10 +122,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 }
 

--- a/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
+++ b/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
@@ -22,11 +22,11 @@ public class TextIndexUtilsTest
         if (actualIndex != null)
         {
             var actualTextIndex = new TextIndex(actualIndex.Value, state);
-            Assert.AreEqual(TextIndexUtils.Clamp(textIndex, minIndex, maxIndex), actualTextIndex);
+            Assert.That(actualTextIndex, Is.EqualTo(TextIndexUtils.Clamp(textIndex, minIndex, maxIndex)));
         }
         else
         {
-            Assert.Throws<ArgumentException>(() => TextIndexUtils.Clamp(textIndex, minIndex, maxIndex));
+            Assert.That((Action)(() => TextIndexUtils.Clamp(textIndex, minIndex, maxIndex)), Throws.TypeOf<ArgumentException>());
         }
     }
 
@@ -39,7 +39,7 @@ public class TextIndexUtilsTest
         var textIndex = new TextIndex(index, state);
 
         int actual = TextIndexUtils.ToStringIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(TextIndex.IndexState.Start, TextIndex.IndexState.End)]
@@ -47,7 +47,7 @@ public class TextIndexUtilsTest
     public void TestReverseState(TextIndex.IndexState state, TextIndex.IndexState expected)
     {
         var actual = TextIndexUtils.ReverseState(state);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(1, TextIndex.IndexState.End, 1, TextIndex.IndexState.Start)]
@@ -60,7 +60,7 @@ public class TextIndexUtilsTest
 
         var expected = new TextIndex(expectedIndex, expectedState);
         var actual = TextIndexUtils.GetPreviousIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(0, TextIndex.IndexState.Start, 0, TextIndex.IndexState.End)]
@@ -73,6 +73,6 @@ public class TextIndexUtilsTest
 
         var expected = new TextIndex(expectedIndex, expectedState);
         var actual = TextIndexUtils.GetNextIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 }

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -153,10 +153,10 @@ public partial class TestSceneLyricSpriteTextCharacterPosition : BackgroundGridT
         {
             AddStep("Oops", () =>
             {
-                Assert.Catch<ArgumentOutOfRangeException>(() =>
+                Assert.That((Action)(() =>
                 {
                     func();
-                });
+                }), Throws.InstanceOf<ArgumentOutOfRangeException>());
             });
         }
 

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.605.1" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework.Font\osu.Framework.Font.csproj" />

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>

--- a/osu.Framework.Font/Graphics/Shaders/CustomizedShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/CustomizedShader.cs
@@ -22,9 +22,6 @@ public abstract class CustomizedShader : ICustomizedShader
 
     public void Unbind() => shader.Unbind();
 
-    public Uniform<T> GetUniform<T>(string name) where T : unmanaged, IEquatable<T>
-        => shader.GetUniform<T>(name);
-
     public void BindUniformBlock(string blockName, IUniformBuffer buffer)
         => shader.BindUniformBlock(blockName, buffer);
 

--- a/osu.Framework.Font/Graphics/Shaders/ICustomizedShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ICustomizedShader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics.Rendering;
 
 namespace osu.Framework.Graphics.Shaders;
@@ -29,14 +28,6 @@ public interface ICustomizedShader
     /// Whether this shader is currently bound.
     /// </summary>
     bool IsBound { get; }
-
-    /// <summary>
-    /// Retrieves a uniform from the shader.
-    /// </summary>
-    /// <param name="name">The name of the uniform.</param>
-    /// <returns>The retrieved uniform.</returns>
-    Uniform<T> GetUniform<T>(string name)
-        where T : unmanaged, IEquatable<T>;
 
     /// <summary>
     /// Binds an <see cref="IUniformBuffer"/> to a uniform block of the given name.

--- a/osu.Framework.Font/Graphics/Shaders/StepShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/StepShader.cs
@@ -38,9 +38,6 @@ public class StepShader : IStepShader, IApplicableToCharacterSize, IApplicableTo
     public void Unbind()
         => throw new NotSupportedException();
 
-    public Uniform<T> GetUniform<T>(string name) where T : unmanaged, IEquatable<T>
-        => throw new NotSupportedException();
-
     public void BindUniformBlock(string blockName, IUniformBuffer buffer)
         => throw new NotSupportedException();
 

--- a/osu.Framework.Font/osu.Framework.Font.csproj
+++ b/osu.Framework.Font/osu.Framework.Font.csproj
@@ -28,7 +28,7 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework" Version="2025.604.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2026.629.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*" />


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` capturing the dependency-update playbook discovered while doing a manual package bump pass (see #550): commit grouping from `.github/dependabot.yml`, cross-checking versions against `ppy/osu-framework` before trusting NuGet's "latest", the NUnit 3→4 classic-`Assert` migration pattern, a local build/test verification checklist, and — learned the hard way this session — which of this repo's two remotes (`karaoke` vs `origin`) is the actual PR target.

## Why
So a future agent-driven update session doesn't have to rediscover the same breakage (e.g. the `IShader.GetUniform<T>()` removal, the `Assert.Throws`/`Assert.That` ambiguous-overload gotcha), and doesn't repeat this session's mistake of opening PRs against the wrong repo (`andy840119/osu-framework-font`, a personal fork, instead of this canonical `karaoke-dev/osu-framework-font`).

Note: this was previously opened and merged as andy840119/osu-framework-font#184 against the wrong repo. Re-opening the same change (plus the remote-clarification addendum) against `karaoke-dev/osu-framework-font` directly.