### PR TITLE
Update to osu!framework 2026.807.0

### DIFF
--- a/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
+++ b/osu.Framework.Font/Graphics/MultiShaderBufferedDrawNodeSharedData.cs
@@ -18,7 +18,7 @@ public class MultiShaderBufferedDrawNodeSharedData : BufferedDrawNodeSharedData
     private readonly RenderBufferFormat[]? formats;
 
     public MultiShaderBufferedDrawNodeSharedData(RenderBufferFormat[]? formats = null, bool pixelSnapping = false)
-        : base(0, formats, pixelSnapping)
+        : base(0, TexturePixelFormat.R8G8B8A8Float, formats, pixelSnapping)
     {
         this.formats = formats;
     }
@@ -58,11 +58,11 @@ public class MultiShaderBufferedDrawNodeSharedData : BufferedDrawNodeSharedData
             case IStepShader stepShader:
             {
                 var stepShaderAmount = Math.Min(stepShader.StepShaders.Count, 2);
-                return new BufferedDrawNodeSharedData(stepShaderAmount, formats, PixelSnapping, ClipToRootNode);
+                return new BufferedDrawNodeSharedData(stepShaderAmount, TexturePixelFormat.R8G8B8A8Float, formats, PixelSnapping, ClipToRootNode);
             }
 
             default:
-                return new BufferedDrawNodeSharedData(formats, PixelSnapping, ClipToRootNode);
+                return new BufferedDrawNodeSharedData(TexturePixelFormat.R8G8B8A8Float, formats, PixelSnapping, ClipToRootNode);
         }
     }
 

--- a/osu.Framework.Font/osu.Framework.Font.csproj
+++ b/osu.Framework.Font/osu.Framework.Font.csproj
@@ -28,7 +28,7 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework" Version="2026.629.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2026.807.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*" />


### PR DESCRIPTION
## Summary

- update `ppy.osu.Framework` from `2026.629.0` to `2026.807.0`
- pass the new `TexturePixelFormat` argument to `BufferedDrawNodeSharedData` constructors
- preserve the previous default framebuffer format (`R8G8B8A8Float`)

## Why

The `BufferedDrawNodeSharedData` constructor signature changed in newer osu!framework releases. A font assembly built against the older signature throws `MissingMethodException` when the karaoke settings preview creates its shader buffers under a current osu! installation.

## Testing

- library Release build succeeds with 0 warnings and 0 errors
- test project Release build succeeds with 0 warnings and 0 errors
- non-visual test suite passes (100 passed)

Companion dependency update for karaoke-dev/karaoke#2343.