### PR TITLE
Move recurring-task playbooks out of CLAUDE.md into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,5 +7,5 @@ Unofficial osu!framework extension for extra font/text effects (outline, shadow,
 Detailed, recurring-task playbooks live under [`docs/`](docs/) so this file stays short:
 
 - [docs/upgrading-dependencies.md](docs/upgrading-dependencies.md) — the "update the important packages, fix any test failures, one commit per category" task: dependabot commit grouping, cross-checking versions against `ppy/osu-framework`, the NUnit 3 → 4 `Assert.*` migration, and the local verification checklist.
-- [docs/opening-a-pull-request.md](docs/opening-a-pull-request.md) — this repo has two remotes (`karaoke` = canonical upstream, `origin` = personal fork); PRs go to `karaoke`, not `origin`.
+- [docs/opening-a-pull-request.md](docs/opening-a-pull-request.md) — this repo has two remotes (`karaoke` = canonical upstream, `origin` = personal fork); push branches to `origin`, but open the PR's base against `karaoke-dev/osu-framework-font`.
 - [docs/tag-releases.md](docs/tag-releases.md) — tag naming convention (`YYYY.MMDD.PATCH`) and why release tags must be pushed to `karaoke` (nuget.org Trusted Publishing is locked to that repo).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,56 +2,10 @@
 
 Unofficial osu!framework extension for extra font/text effects (outline, shadow, step shaders). Single desktop target (net8.0): `osu.Framework.Font` (library) + `osu.Framework.Font.Tests` (NUnit + visual test browser).
 
-## Updating dependencies
+## Playbooks
 
-This is a recurring task ("update the important packages, fix any test failures, one commit per category"). Follow this playbook — it encodes real breakage found while doing this by hand.
+Detailed, recurring-task playbooks live under [`docs/`](docs/) so this file stays short:
 
-### 1. Commit grouping from `.github/dependabot.yml`
-
-- **osu-related** group: `ppy.osu.Framework`, `ppy.osu.Game.Resources` — bump together, one commit.
-- Everything else (`Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`) is ungrouped — one commit each, matching how dependabot PRs land individually for these.
-
-Check with `dotnet list <csproj> package --outdated` per project (`dotnet list package --outdated` doesn't work directly on a solution/slnf-less repo layout here, but this repo has no `.slnf` — just build/restore at the repo root or per-csproj).
-
-### 2. Cross-check versions against `ppy/osu-framework` before trusting "latest"
-
-This repo depends directly on `ppy.osu.Framework`, so a "latest" bump can be a large jump (e.g. a full year of upstream releases). Before assuming a compile error is *your* bug:
-
-- Search upstream for the removed/changed symbol: `gh api "search/code?q=repo:ppy/osu-framework+filename:<Name>.cs"` to find where a type now lives, then `gh api "repos/ppy/osu-framework/commits?path=<file>"` to read *why* it changed (the commit message usually explains whether there's a real replacement or the old member was already dead).
-- Example hit from 2025.604.1 → 2026.629.0: `IShader.GetUniform<T>()` was removed (`osu.Framework/Graphics/Shaders/IShader.cs`). The upstream removal commit explained the method had been non-functional since `GlobalPropertyManager` was deleted years earlier — so the fix was deleting the matching dead passthrough in `ICustomizedShader`/`CustomizedShader`/`StepShader` (which already just threw `NotSupportedException` in `StepShader`, confirming nothing real depended on it), not finding a replacement API.
-- For `NUnit`/`NUnit3TestAdapter`/`Microsoft.NET.Test.Sdk`, this repo's own dependabot history tracks NuGet's latest independently of `ppy/osu-framework` (which pins much older test-tooling versions upstream) — keep following latest for these three.
-
-### 3. NUnit 3 → 4 major bump breaks classic `Assert.*` calls
-
-NUnit 4 removed the classic assertion methods (`Assert.AreEqual`, `AreNotEqual`, `Throws<T>(...)`, `Catch<T>(...)`) from the `Assert` class — they now live under `NUnit.Framework.Legacy.ClassicAssert` (separate namespace/DLL). Two migration paths; **use the constraint model** (what upstream NUnit recommends, and what was done here), not the `ClassicAssert` shim:
-
-```csharp
-Assert.AreEqual(expected, actual);        // ->  Assert.That(actual, Is.EqualTo(expected));
-Assert.AreNotEqual(expected, actual);     // ->  Assert.That(actual, Is.Not.EqualTo(expected));
-Assert.Throws<TEx>(() => Code());         // ->  Assert.That((Action)(() => Code()), Throws.TypeOf<TEx>());
-Assert.Catch<TEx>(() => Code());          // ->  Assert.That((Action)(() => Code()), Throws.InstanceOf<TEx>());
-```
-
-Gotcha: `Assert.That(() => ..., constraint)` is **ambiguous** (`CS0121`) between the `TestDelegate` and `Action` overloads when the argument is a bare lambda — NUnit kept both overloads and their signatures collide. Cast the lambda explicitly: `(Action)(() => ...)`. (`(TestDelegate)(...)` also compiles but is itself marked `[Obsolete]` — use `Action`.)
-
-If a repo already targets NUnit 4 (check the `.csproj` before assuming this migration is needed — not every repo in this org is still on NUnit 3), this step is a no-op.
-
-### 4. Local verification checklist
-
-```
-dotnet restore
-dotnet build            # 0 warnings / 0 errors is the bar — CI treats this repo's build as the test gate
-dotnet test             # run the full suite, confirm N/N passing, not just "build succeeded"
-dotnet list package --outdated   # run again after all bumps — should report nothing left outdated
-                                   # (aside from anything intentionally skipped, see section 2)
-```
-
-### 5. Committing and PR workflow
-
-- One commit per dependabot group/category (section 1), each with build+test passing before moving to the next.
-- **This repo has two remotes — check `git remote -v` before opening a PR, don't assume `origin` is the target:**
-  - `karaoke` → `karaoke-dev/osu-framework-font` — **this is the canonical upstream repo. PRs go here.**
-  - `origin` → `andy840119/osu-framework-font` — a personal fork/mirror. A PR opened against this one is easy to merge into the wrong place by mistake (it happened once — see PRs #183/#184, which were merged into the fork and then had to be re-opened against `karaoke-dev/osu-framework-font` as new PRs).
-  - Confirm which is which with `gh api repos/karaoke-dev/osu-framework-font --jq .permissions` (push access implies it's a legitimate target) rather than guessing from remote name alone — org names have changed before (`osu-karaoke` → `karaoke-dev` in the sibling `osu-framework-microphone` repo, which redirects automatically).
-- Branch from `karaoke/master` (`git fetch karaoke master` first), push to `karaoke`, then `gh pr create --repo karaoke-dev/osu-framework-font --base master --head <branch>`. Do **not** default to `origin`/`andy840119/osu-framework-font` unless the user explicitly asks for that fork specifically.
-- If CI doesn't run on the PR, check `gh api repos/<owner>/<repo>/actions/permissions` — Actions can simply be disabled on a personal fork (`"enabled": false`), which is a repo-settings problem, not a workflow-file problem. Confirm the workflow YAML itself is correct before concluding CI is broken.
+- [docs/upgrading-dependencies.md](docs/upgrading-dependencies.md) — the "update the important packages, fix any test failures, one commit per category" task: dependabot commit grouping, cross-checking versions against `ppy/osu-framework`, the NUnit 3 → 4 `Assert.*` migration, and the local verification checklist.
+- [docs/opening-a-pull-request.md](docs/opening-a-pull-request.md) — this repo has two remotes (`karaoke` = canonical upstream, `origin` = personal fork); PRs go to `karaoke`, not `origin`.
+- [docs/tag-releases.md](docs/tag-releases.md) — tag naming convention (`YYYY.MMDD.PATCH`) and why release tags must be pushed to `karaoke` (nuget.org Trusted Publishing is locked to that repo).

--- a/docs/opening-a-pull-request.md
+++ b/docs/opening-a-pull-request.md
@@ -1,11 +1,13 @@
 # Opening a pull request
 
-**This repo has two remotes — check `git remote -v` before opening a PR, don't assume `origin` is the target:**
+**This repo has two remotes — check `git remote -v` before opening a PR:**
 
-- `karaoke` → `karaoke-dev/osu-framework-font` — **this is the canonical upstream repo. PRs go here.**
-- `origin` → `andy840119/osu-framework-font` — a personal fork/mirror. A PR opened against this one is easy to merge into the wrong place by mistake (it happened once — see PRs #183/#184, which were merged into the fork and then had to be re-opened against `karaoke-dev/osu-framework-font` as new PRs).
+- `karaoke` → `karaoke-dev/osu-framework-font` — the canonical upstream repo. **PRs target this repo as their base**, but branches aren't pushed here directly.
+- `origin` → `andy840119/osu-framework-font` — personal fork. **Push branches here**, then open the PR cross-repo against `karaoke-dev/osu-framework-font`.
 
 Confirm which is which with `gh api repos/karaoke-dev/osu-framework-font --jq .permissions` (push access implies it's a legitimate target) rather than guessing from remote name alone — org names have changed before (`osu-karaoke` → `karaoke-dev` in the sibling `osu-framework-microphone` repo, which redirects automatically).
+
+Don't confuse "push to `origin`" with "PR against `origin`" — those are different repos. A PR whose **base repo** is `andy840119/osu-framework-font` is wrong and easy to create by accident (it happened once — see PRs #183/#184, which were merged into the fork and then had to be re-opened against `karaoke-dev/osu-framework-font` as new PRs). The base repo must always be `karaoke-dev/osu-framework-font`; only the head branch lives on `origin`.
 
 ## Workflow
 
@@ -13,12 +15,12 @@ Confirm which is which with `gh api repos/karaoke-dev/osu-framework-font --jq .p
 git fetch karaoke master
 git checkout -b <branch> karaoke/master
 # ...make changes, commit...
-git push -u karaoke <branch>
-gh pr create --repo karaoke-dev/osu-framework-font --base master --head <branch>
+git push -u origin <branch>
+gh pr create --repo karaoke-dev/osu-framework-font --base master --head andy840119:<branch>
 ```
 
-Do **not** default to `origin`/`andy840119/osu-framework-font` unless the user explicitly asks for that fork specifically.
+The `--head andy840119:<branch>` form is required for a cross-repo PR — a bare `--head <branch>` would look for the branch inside `karaoke-dev/osu-framework-font` itself and fail (or worse, silently target the wrong branch if one with the same name happens to exist there).
 
 ## If CI doesn't run on the PR
 
-Check `gh api repos/<owner>/<repo>/actions/permissions` — Actions can simply be disabled on a personal fork (`"enabled": false`), which is a repo-settings problem, not a workflow-file problem. Confirm the workflow YAML itself is correct before concluding CI is broken.
+`dotnet-core.yml` triggers on `pull_request: branches: [master]`, so once the PR's base repo is correctly `karaoke-dev/osu-framework-font`, CI runs there regardless of the fork's own Actions settings. If it still doesn't run, check `gh api repos/karaoke-dev/osu-framework-font/actions/permissions` and confirm the PR's base repo is actually `karaoke-dev/osu-framework-font` and not the fork — Actions being disabled on the personal fork only matters if the PR was mistakenly opened against the fork itself.

--- a/docs/opening-a-pull-request.md
+++ b/docs/opening-a-pull-request.md
@@ -1,0 +1,24 @@
+# Opening a pull request
+
+**This repo has two remotes — check `git remote -v` before opening a PR, don't assume `origin` is the target:**
+
+- `karaoke` → `karaoke-dev/osu-framework-font` — **this is the canonical upstream repo. PRs go here.**
+- `origin` → `andy840119/osu-framework-font` — a personal fork/mirror. A PR opened against this one is easy to merge into the wrong place by mistake (it happened once — see PRs #183/#184, which were merged into the fork and then had to be re-opened against `karaoke-dev/osu-framework-font` as new PRs).
+
+Confirm which is which with `gh api repos/karaoke-dev/osu-framework-font --jq .permissions` (push access implies it's a legitimate target) rather than guessing from remote name alone — org names have changed before (`osu-karaoke` → `karaoke-dev` in the sibling `osu-framework-microphone` repo, which redirects automatically).
+
+## Workflow
+
+```
+git fetch karaoke master
+git checkout -b <branch> karaoke/master
+# ...make changes, commit...
+git push -u karaoke <branch>
+gh pr create --repo karaoke-dev/osu-framework-font --base master --head <branch>
+```
+
+Do **not** default to `origin`/`andy840119/osu-framework-font` unless the user explicitly asks for that fork specifically.
+
+## If CI doesn't run on the PR
+
+Check `gh api repos/<owner>/<repo>/actions/permissions` — Actions can simply be disabled on a personal fork (`"enabled": false`), which is a repo-settings problem, not a workflow-file problem. Confirm the workflow YAML itself is correct before concluding CI is broken.

--- a/docs/tag-releases.md
+++ b/docs/tag-releases.md
@@ -1,0 +1,36 @@
+# Tag releases
+
+Pushing a tag to the canonical repo triggers [`.github/workflows/deploy-pack.yml`](../.github/workflows/deploy-pack.yml) (`Tagged Release`), which builds `osu.Framework.Font`, packs it with `/p:Version=<tag>`, and publishes the `.nupkg` to nuget.org.
+
+## Tag naming convention
+
+`YYYY.MMDD.PATCH`, matching this repo's own version history (`git tag -l | sort -V`), e.g.:
+
+```
+2025.0511.0
+2025.0607.0
+2026.0718.0
+2026.0813.0
+```
+
+- `YYYY` — 4-digit year.
+- `MMDD` — 4-digit, zero-padded month + day (e.g. August 13th → `0813`, not `813`).
+- `PATCH` — starts at `0` for the first release of that day; bump to `1`, `2`, ... if a second release goes out the same day (e.g. `2023.0627.0` then `2023.0627.1`).
+- Pre-releases use a `-alpha` suffix on the patch segment, e.g. `2022.0806.1-alpha`.
+
+There's no separate `v` prefix — tags are the bare version string, since that string is passed straight through as the package's `Version`.
+
+## Which remote to push the tag to
+
+Push tags to `karaoke` (`karaoke-dev/osu-framework-font`), **not** `origin` (the personal fork). Two independent reasons this matters, not just convention:
+
+1. The `Tagged Release` workflow only runs where it's pushed. A tag pushed to `origin` runs whatever workflow exists on that fork (if Actions are even enabled there — see [opening-a-pull-request.md](opening-a-pull-request.md)), not the canonical one.
+2. Publishing now uses [nuget.org Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) (OIDC, via `NuGet/login@v1` in the `release` job) instead of a long-lived API key secret. The trusted publishing policy on nuget.org is locked to a specific `(repository owner, repository, workflow file)` triple — currently `karaoke-dev` / `osu-framework-font` / `deploy-pack.yml`. A run from any other repo (including the personal fork) will fail to exchange its OIDC token for a NuGet API key, even if the workflow file itself is identical.
+
+```
+git fetch karaoke master
+git tag 2026.0813.0        # on the commit you want released, following the convention above
+git push karaoke 2026.0813.0
+```
+
+Then watch it with `gh run list --repo karaoke-dev/osu-framework-font --workflow=deploy-pack.yml --limit 1`.

--- a/docs/upgrading-dependencies.md
+++ b/docs/upgrading-dependencies.md
@@ -1,0 +1,47 @@
+# Upgrading dependencies
+
+This is a recurring task ("update the important packages, fix any test failures, one commit per category"). Follow this playbook — it encodes real breakage found while doing this by hand.
+
+## 1. Commit grouping from `.github/dependabot.yml`
+
+- **osu-related** group: `ppy.osu.Framework`, `ppy.osu.Game.Resources` — bump together, one commit.
+- Everything else (`Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`) is ungrouped — one commit each, matching how dependabot PRs land individually for these.
+
+Check with `dotnet list <csproj> package --outdated` per project (`dotnet list package --outdated` doesn't work directly on a solution/slnf-less repo layout here, but this repo has no `.slnf` — just build/restore at the repo root or per-csproj).
+
+## 2. Cross-check versions against `ppy/osu-framework` before trusting "latest"
+
+This repo depends directly on `ppy.osu.Framework`, so a "latest" bump can be a large jump (e.g. a full year of upstream releases). Before assuming a compile error is *your* bug:
+
+- Search upstream for the removed/changed symbol: `gh api "search/code?q=repo:ppy/osu-framework+filename:<Name>.cs"` to find where a type now lives, then `gh api "repos/ppy/osu-framework/commits?path=<file>"` to read *why* it changed (the commit message usually explains whether there's a real replacement or the old member was already dead).
+- Example hit from 2025.604.1 → 2026.629.0: `IShader.GetUniform<T>()` was removed (`osu.Framework/Graphics/Shaders/IShader.cs`). The upstream removal commit explained the method had been non-functional since `GlobalPropertyManager` was deleted years earlier — so the fix was deleting the matching dead passthrough in `ICustomizedShader`/`CustomizedShader`/`StepShader` (which already just threw `NotSupportedException` in `StepShader`, confirming nothing real depended on it), not finding a replacement API.
+- For `NUnit`/`NUnit3TestAdapter`/`Microsoft.NET.Test.Sdk`, this repo's own dependabot history tracks NuGet's latest independently of `ppy/osu-framework` (which pins much older test-tooling versions upstream) — keep following latest for these three.
+
+## 3. NUnit 3 → 4 major bump breaks classic `Assert.*` calls
+
+NUnit 4 removed the classic assertion methods (`Assert.AreEqual`, `AreNotEqual`, `Throws<T>(...)`, `Catch<T>(...)`) from the `Assert` class — they now live under `NUnit.Framework.Legacy.ClassicAssert` (separate namespace/DLL). Two migration paths; **use the constraint model** (what upstream NUnit recommends, and what was done here), not the `ClassicAssert` shim:
+
+```csharp
+Assert.AreEqual(expected, actual);        // ->  Assert.That(actual, Is.EqualTo(expected));
+Assert.AreNotEqual(expected, actual);     // ->  Assert.That(actual, Is.Not.EqualTo(expected));
+Assert.Throws<TEx>(() => Code());         // ->  Assert.That((Action)(() => Code()), Throws.TypeOf<TEx>());
+Assert.Catch<TEx>(() => Code());          // ->  Assert.That((Action)(() => Code()), Throws.InstanceOf<TEx>());
+```
+
+Gotcha: `Assert.That(() => ..., constraint)` is **ambiguous** (`CS0121`) between the `TestDelegate` and `Action` overloads when the argument is a bare lambda — NUnit kept both overloads and their signatures collide. Cast the lambda explicitly: `(Action)(() => ...)`. (`(TestDelegate)(...)` also compiles but is itself marked `[Obsolete]` — use `Action`.)
+
+If a repo already targets NUnit 4 (check the `.csproj` before assuming this migration is needed — not every repo in this org is still on NUnit 3), this step is a no-op.
+
+## 4. Local verification checklist
+
+```
+dotnet restore
+dotnet build            # 0 warnings / 0 errors is the bar — CI treats this repo's build as the test gate
+dotnet test             # run the full suite, confirm N/N passing, not just "build succeeded"
+dotnet list package --outdated   # run again after all bumps — should report nothing left outdated
+                                   # (aside from anything intentionally skipped, see section 2)
+```
+
+## 5. Committing
+
+One commit per dependabot group/category (section 1), each with build+test passing before moving to the next. Then open a PR — see [opening-a-pull-request.md](opening-a-pull-request.md).


### PR DESCRIPTION
## Summary
- CLAUDE.md was growing every time a new recurring-task playbook got added. Splits it into `docs/`:
  - `docs/upgrading-dependencies.md` — the dependency-upgrade playbook (dependabot grouping, cross-checking against `ppy/osu-framework`, NUnit 3→4 `Assert.*` migration, verification checklist).
  - `docs/opening-a-pull-request.md` — the two-remotes (`karaoke` vs `origin`) PR workflow.
  - `docs/tag-releases.md` — new: documents the `YYYY.MMDD.PATCH` tag naming convention (derived from `git tag -l | sort -V`) and why release tags must be pushed to `karaoke`, not `origin` — nuget.org's Trusted Publishing policy (added in #555) is locked to the `karaoke-dev/osu-framework-font` repo, so a tag pushed to the personal fork would fail to authenticate even with an identical workflow file.
- CLAUDE.md now just links to these three docs.

## Test plan
- [x] Skim each doc for accuracy against current repo state.
- [x] No code changes — build/test are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)